### PR TITLE
Pets 도메인 - 반려동물 CRUD API

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/controller/PetController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/controller/PetController.java
@@ -1,0 +1,80 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.controller;
+
+import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.PetCreateRequest;
+import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.PetUpdateRequest;
+import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetResponse;
+import com.newleaseonlife.SafeDogBe.domain.pet.service.PetService;
+import com.newleaseonlife.SafeDogBe.global.security.CustomPrincipal;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/pets")
+@RequiredArgsConstructor
+public class PetController {
+
+    private final PetService petService;
+
+    @GetMapping
+    public ResponseEntity<List<PetResponse>> getMyPets(
+            @AuthenticationPrincipal CustomPrincipal principal) {
+        log.info("[PetController] 내 반려동물 목록 조회 userId={}", principal.getUser().getId());
+        List<PetResponse> response = petService.findMyPets(principal.getUser().getId());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{petId}")
+    public ResponseEntity<PetResponse> getPet(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @PathVariable Long petId) {
+        log.info("[PetController] 반려동물 조회 petId={}, userId={}", petId, principal.getUser().getId());
+        PetResponse response = petService.findById(petId, principal.getUser().getId());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping
+    public ResponseEntity<PetResponse> createPet(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @Valid @RequestBody PetCreateRequest request) {
+        log.info("[PetController] 반려동물 등록 userId={}, name={}", principal.getUser().getId(), request.getName());
+        PetResponse response = petService.create(principal.getUser().getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PatchMapping("/{petId}")
+    public ResponseEntity<PetResponse> updatePet(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @PathVariable Long petId,
+            @Valid @RequestBody PetUpdateRequest request) {
+        log.info("[PetController] 반려동물 수정 petId={}, userId={}", petId, principal.getUser().getId());
+        PetResponse response = petService.update(petId, principal.getUser().getId(), request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{petId}")
+    public ResponseEntity<Void> deletePet(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @PathVariable Long petId) {
+        log.info("[PetController] 반려동물 삭제 petId={}, userId={}", petId, principal.getUser().getId());
+        petService.delete(petId, principal.getUser().getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/converter/PetConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/converter/PetConverter.java
@@ -1,0 +1,34 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.converter;
+
+import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetResponse;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class PetConverter {
+
+    public PetResponse toResponse(Pet pet) {
+        return PetResponse.builder()
+                .id(pet.getId())
+                .userId(pet.getUser().getId())
+                .name(pet.getName())
+                .species(pet.getSpecies())
+                .breed(pet.getBreed())
+                .birthDate(pet.getBirthDate())
+                .gender(pet.getGender())
+                .isNeutered(pet.isNeutered())
+                .profileImageUrl(pet.getProfileImageUrl())
+                .createdAt(pet.getCreatedAt())
+                .updatedAt(pet.getUpdatedAt())
+                .build();
+    }
+
+    public List<PetResponse> toResponseList(List<Pet> pets) {
+        return pets.stream()
+                .map(this::toResponse)
+                .toList();
+    }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetCreateRequest.java
@@ -1,0 +1,39 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.dto.request;
+
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PetCreateRequest {
+
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(max = 100)
+    private String name;
+
+    @Size(max = 50)
+    private String species;
+
+    @Size(max = 100)
+    private String breed;
+
+    private LocalDate birthDate;
+
+    private Gender gender;
+
+    private Boolean isNeutered;
+
+    @Size(max = 500)
+    private String profileImageUrl;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetUpdateRequest.java
@@ -1,0 +1,37 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.dto.request;
+
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
+
+import jakarta.validation.constraints.Size;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PetUpdateRequest {
+
+    @Size(max = 100)
+    private String name;
+
+    @Size(max = 50)
+    private String species;
+
+    @Size(max = 100)
+    private String breed;
+
+    private LocalDate birthDate;
+
+    private Gender gender;
+
+    private Boolean isNeutered;
+
+    @Size(max = 500)
+    private String profileImageUrl;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/response/PetResponse.java
@@ -1,0 +1,30 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.dto.response;
+
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PetResponse {
+
+    private Long id;
+    private Long userId;
+    private String name;
+    private String species;
+    private String breed;
+    private LocalDate birthDate;
+    private Gender gender;
+    private boolean isNeutered;
+    private String profileImageUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/Pet.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/Pet.java
@@ -1,0 +1,98 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.entity;
+
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "pets")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Pet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(length = 50)
+    private String species;
+
+    @Column(length = 100)
+    private String breed;
+
+    private LocalDate birthDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 10)
+    private Gender gender;
+
+    @Column(nullable = false)
+    private boolean isNeutered = false;
+
+    @Column(length = 500)
+    private String profileImageUrl;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Pet(User user, String name, String species, String breed, LocalDate birthDate,
+               Gender gender, boolean isNeutered, String profileImageUrl) {
+        this.user = user;
+        this.name = name;
+        this.species = species;
+        this.breed = breed;
+        this.birthDate = birthDate;
+        this.gender = gender;
+        this.isNeutered = isNeutered;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void update(String name, String species, String breed, LocalDate birthDate,
+                       Gender gender, Boolean isNeutered, String profileImageUrl) {
+        if (name != null) this.name = name;
+        if (species != null) this.species = species;
+        if (breed != null) this.breed = breed;
+        if (birthDate != null) this.birthDate = birthDate;
+        if (gender != null) this.gender = gender;
+        if (isNeutered != null) this.isNeutered = isNeutered;
+        if (profileImageUrl != null) this.profileImageUrl = profileImageUrl;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/enums/Gender.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/enums/Gender.java
@@ -1,0 +1,6 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.entity.enums;
+
+public enum Gender {
+    MALE,
+    FEMALE
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/repository/PetRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/repository/PetRepository.java
@@ -1,0 +1,17 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.repository;
+
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PetRepository extends JpaRepository<Pet, Long> {
+
+    List<Pet> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Optional<Pet> findByIdAndUserId(Long id, Long userId);
+
+    boolean existsByIdAndUserId(Long id, Long userId);
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/service/PetService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/service/PetService.java
@@ -1,0 +1,109 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.service;
+
+import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.PetCreateRequest;
+import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.PetUpdateRequest;
+import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetResponse;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+import com.newleaseonlife.SafeDogBe.domain.pet.converter.PetConverter;
+import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetRepository;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.PetErrorCode;
+import com.newleaseonlife.SafeDogBe.global.error.domain.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PetService {
+
+    private final PetRepository petRepository;
+    private final UserRepository userRepository;
+    private final PetConverter petConverter;
+
+    public List<PetResponse> findMyPets(Long userId) {
+        log.debug("[PetService] findMyPets userId={}", userId);
+        List<Pet> pets = petRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+        return petConverter.toResponseList(pets);
+    }
+
+    public PetResponse findById(Long petId, Long userId) {
+        log.debug("[PetService] findById petId={}, userId={}", petId, userId);
+        Pet pet = petRepository.findByIdAndUserId(petId, userId)
+                .orElseThrow(() -> {
+                    if (petRepository.findById(petId).isEmpty()) {
+                        return new BusinessException(PetErrorCode.PET_NOT_FOUND);
+                    }
+                    return new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
+                });
+        return petConverter.toResponse(pet);
+    }
+
+    @Transactional
+    public PetResponse create(Long userId, PetCreateRequest request) {
+        log.info("[PetService] create userId={}, name={}", userId, request.getName());
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        boolean isNeutered = request.getIsNeutered() != null && request.getIsNeutered();
+        Pet pet = Pet.builder()
+                .user(user)
+                .name(request.getName())
+                .species(request.getSpecies())
+                .breed(request.getBreed())
+                .birthDate(request.getBirthDate())
+                .gender(request.getGender())
+                .isNeutered(isNeutered)
+                .profileImageUrl(request.getProfileImageUrl())
+                .build();
+        petRepository.save(pet);
+        log.info("[PetService] create 완료 petId={}", pet.getId());
+        return petConverter.toResponse(pet);
+    }
+
+    @Transactional
+    public PetResponse update(Long petId, Long userId, PetUpdateRequest request) {
+        log.info("[PetService] update petId={}, userId={}", petId, userId);
+        Pet pet = petRepository.findByIdAndUserId(petId, userId)
+                .orElseThrow(() -> {
+                    if (petRepository.findById(petId).isEmpty()) {
+                        return new BusinessException(PetErrorCode.PET_NOT_FOUND);
+                    }
+                    return new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
+                });
+
+        pet.update(
+                request.getName(),
+                request.getSpecies(),
+                request.getBreed(),
+                request.getBirthDate(),
+                request.getGender(),
+                request.getIsNeutered(),
+                request.getProfileImageUrl()
+        );
+        log.info("[PetService] update 완료 petId={}", petId);
+        return petConverter.toResponse(pet);
+    }
+
+    @Transactional
+    public void delete(Long petId, Long userId) {
+        log.info("[PetService] delete petId={}, userId={}", petId, userId);
+        if (!petRepository.existsByIdAndUserId(petId, userId)) {
+            if (petRepository.findById(petId).isEmpty()) {
+                throw new BusinessException(PetErrorCode.PET_NOT_FOUND);
+            }
+            throw new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
+        }
+        petRepository.deleteById(petId);
+        log.info("[PetService] delete 완료 petId={}", petId);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#21 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

- Pets 도메인 추가: 반려동물 등록·목록 조회·단건 조회·수정·삭제 API
- User 1:N Pet 구조, 인증 사용자만 본인 반려동물에 대해 접근 가능
- Pet 엔티티 (name, species, breed, birthDate, gender, isNeutered, profileImageUrl)
- PetController: `GET /api/pets`, `GET /api/pets/{petId}`, `POST /api/pets`, `PATCH /api/pets/{petId}`, `DELETE /api/pets/{petId}`

## 🛠️ 주요 변경 사항 및 리팩토링

- `domain.pet` 패키지 추가: entity, repository, dto(request/response), converter, service, controller
- Gender enum (MALE, FEMALE)
- PetErrorCode 사용: PET_NOT_FOUND(404), PET_ACCESS_DENIED(403)
- 단건/목록 응답 모두 PetConverter 경유 (toResponse, toResponseList)
- SecurityConfig 변경 없음 — `/api/pets/**` 는 `anyRequest().authenticated()` 로 인증 필요

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

## ✅ 체크리스트

- [x] 브랜치 전략(소문자)을 준수했나요?
- [x] 커밋 메시지 규칙을 지켰나요?
- [x] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [x] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

- DB에 `pets` 테이블이 없으면 JPA ddl-auto 또는 별도 DDL로 생성 필요
- 추후 반려노트/체크리스트 도메인에서 Pet 참조 시 사용 예정