### PR TITLE
User 도메인 확장 - 온보딩 완료 및 회원 탈퇴 API

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/controller/UserController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/controller/UserController.java
@@ -17,6 +17,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -45,6 +46,21 @@ public class UserController {
         log.info("[UserController] updateMe 요청 userId={}", principal.getUser().getId());
         UserResponse response = userService.updateProfile(principal.getUser().getId(), request);
         return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/me/onboarding-complete")
+    public ResponseEntity<UserResponse> completeOnboarding(
+            @AuthenticationPrincipal CustomPrincipal principal) {
+        log.info("[UserController] onboarding-complete 요청 userId={}", principal.getUser().getId());
+        UserResponse response = userService.completeOnboarding(principal.getUser().getId());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/me/withdraw")
+    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal CustomPrincipal principal) {
+        log.info("[UserController] withdraw 요청 userId={}", principal.getUser().getId());
+        userService.withdraw(principal.getUser().getId());
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/check-nickname")

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/converter/UserConverter.java
@@ -18,6 +18,7 @@ public class UserConverter {
                 .providerType(user.getProviderType())
                 .profileImageUrl(user.getProfileImageUrl())
                 .role(user.getRole())
+                .isOnboardingCompleted(user.isOnboardingCompleted())
                 .build();
     }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/dto/response/UserResponse.java
@@ -24,4 +24,5 @@ public class UserResponse {
     private ProviderType providerType;
     private String profileImageUrl;
     private UserRole role;
+    private boolean isOnboardingCompleted;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/entity/User.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/entity/User.java
@@ -75,6 +75,9 @@ public class User {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+    @Column(nullable = false)
+    private boolean isOnboardingCompleted = false;
+
     @Builder
     public User(String email, String password, String nickname, String name, String phone,
                 LocalDate birthDate, String profileImageUrl,
@@ -107,6 +110,18 @@ public class User {
         this.name = name;
         this.phone = phone;
         this.birthDate = birthDate;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /** 온보딩 완료 처리 (최초 로그인 후 한 번만 호출) */
+    public void completeOnboarding() {
+        this.isOnboardingCompleted = true;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    /** 탈퇴 처리 (Soft Delete: status를 WITHDRAWN으로 변경) */
+    public void withdraw() {
+        this.status = UserStatus.WITHDRAWN;
         this.updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/service/UserService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/service/UserService.java
@@ -85,4 +85,29 @@ public class UserService {
             throw new BusinessException(UserErrorCode.ALREADY_REGISTERED_PHONE_NAME);
         }
     }
+
+    @Transactional
+    public UserResponse completeOnboarding(Long userId) {
+        log.info("[UserService] completeOnboarding userId={}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.warn("[UserService] completeOnboarding 실패 - 사용자 없음 userId={}", userId);
+                    return new BusinessException(UserErrorCode.USER_NOT_FOUND);
+                });
+        user.completeOnboarding();
+        log.info("[UserService] completeOnboarding 완료 userId={}", userId);
+        return userConverter.toResponse(user);
+    }
+
+    @Transactional
+    public void withdraw(Long userId) {
+        log.info("[UserService] withdraw userId={}", userId);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.warn("[UserService] withdraw 실패 - 사용자 없음 userId={}", userId);
+                    return new BusinessException(UserErrorCode.USER_NOT_FOUND);
+                });
+        user.withdraw();
+        log.info("[UserService] withdraw 완료 userId={}", userId);
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#23

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

User 도메인 확장으로 **온보딩 완료**와 **회원 탈퇴** 기능을 추가 및 새 도메인/테이블 없이 기존 `users` 테이블과 User 엔티티만 수정

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

### 1. 온보딩 완료

- **엔티티**: `User`에 `isOnboardingCompleted` 필드 추가, `completeOnboarding()` 메서드 추가
- **응답**: `UserResponse`에 `isOnboardingCompleted` 포함 (GET /api/users/me 에서 사용)
- **API**: `PATCH /api/users/me/onboarding-complete` → 200 + 수정된 `UserResponse`

### 2. 회원 탈퇴

- **엔티티**: `User`에 `withdraw()` 메서드 추가 (status → `WITHDRAWN`)
- **API**: `POST /api/users/me/withdraw` → 204 No Content  
- 이미 탈퇴한 사용자도 동일 요청 시 204로 멱등 처리

### 수정된 파일

| 구분 | 파일 |
|------|------|
| 엔티티 | `domain/user/entity/User.java` |
| DTO | `domain/user/dto/response/UserResponse.java` |
| 컨버터 | `domain/user/converter/UserConverter.java` |
| 서비스 | `domain/user/service/UserService.java` |
| 컨트롤러 | `domain/user/controller/UserController.java` |

### DB

- `users` 테이블에 `is_onboarding_completed` 컬럼이 없다면 마이그레이션 추가 필요  
  - 예: `ALTER TABLE users ADD COLUMN is_onboarding_completed BOOLEAN NOT NULL DEFAULT FALSE;`


## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
