### PR TITLE
Petnotes 도메인 구현 - 날짜별 반려동물 기록 CRUD

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/controller/PetNoteController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/controller/PetNoteController.java
@@ -1,0 +1,107 @@
+package com.newleaseonlife.SafeDogBe.domain.petnote.controller;
+
+import com.newleaseonlife.SafeDogBe.domain.petnote.dto.request.PetNoteCreateRequest;
+import com.newleaseonlife.SafeDogBe.domain.petnote.dto.request.PetNoteUpdateRequest;
+import com.newleaseonlife.SafeDogBe.domain.petnote.dto.response.PetNoteResponse;
+import com.newleaseonlife.SafeDogBe.domain.petnote.service.PetNoteService;
+import com.newleaseonlife.SafeDogBe.global.security.CustomPrincipal;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 반려노트 API.
+ * 추후 연결: Pet 도메인 머지 후, petId에 대한 소유권 검증이 서비스 계층에서 이루어지므로
+ * 동일한 엔드포인트를 유지하면서 보안만 강화하면 됨.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/pet-notes")
+@RequiredArgsConstructor
+public class PetNoteController {
+
+    private final PetNoteService petNoteService;
+
+    /** 특정 반려동물의 노트 목록 조회 (날짜 최신순) */
+    @GetMapping
+    public ResponseEntity<List<PetNoteResponse>> getNotesByPetId(
+            @RequestParam Long petId,
+            @AuthenticationPrincipal CustomPrincipal principal) {
+        log.info("[PetNoteController] getNotesByPetId petId={}, userId={}", petId, principal.getUser().getId());
+        List<PetNoteResponse> response = petNoteService.findByPetId(petId, principal.getUser().getId());
+        return ResponseEntity.ok(response);
+    }
+
+    /** 특정 반려동물의 특정 날짜 노트 조회 (날짜별 조회) */
+    @GetMapping("/by-date")
+    public ResponseEntity<List<PetNoteResponse>> getNotesByPetIdAndDate(
+            @RequestParam Long petId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate noteDate,
+            @AuthenticationPrincipal CustomPrincipal principal) {
+        log.info("[PetNoteController] getNotesByPetIdAndDate petId={}, noteDate={}, userId={}",
+                petId, noteDate, principal.getUser().getId());
+        List<PetNoteResponse> response = petNoteService.findByPetIdAndDate(
+                petId, noteDate, principal.getUser().getId());
+        return ResponseEntity.ok(response);
+    }
+
+    /** 반려노트 단건 조회 */
+    @GetMapping("/{noteId}")
+    public ResponseEntity<PetNoteResponse> getNote(
+            @PathVariable Long noteId,
+            @AuthenticationPrincipal CustomPrincipal principal) {
+        log.info("[PetNoteController] getNote noteId={}, userId={}", noteId, principal.getUser().getId());
+        PetNoteResponse response = petNoteService.findById(noteId, principal.getUser().getId());
+        return ResponseEntity.ok(response);
+    }
+
+    /** 반려노트 생성 */
+    @PostMapping
+    public ResponseEntity<PetNoteResponse> createNote(
+            @Valid @RequestBody PetNoteCreateRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal) {
+        log.info("[PetNoteController] createNote petId={}, userId={}", request.getPetId(), principal.getUser().getId());
+        PetNoteResponse response = petNoteService.create(request, principal.getUser().getId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /** 반려노트 수정 */
+    @PatchMapping("/{noteId}")
+    public ResponseEntity<PetNoteResponse> updateNote(
+            @PathVariable Long noteId,
+            @Valid @RequestBody PetNoteUpdateRequest request,
+            @AuthenticationPrincipal CustomPrincipal principal) {
+        log.info("[PetNoteController] updateNote noteId={}, userId={}", noteId, principal.getUser().getId());
+        PetNoteResponse response = petNoteService.update(noteId, request, principal.getUser().getId());
+        return ResponseEntity.ok(response);
+    }
+
+    /** 반려노트 삭제 */
+    @DeleteMapping("/{noteId}")
+    public ResponseEntity<Void> deleteNote(
+            @PathVariable Long noteId,
+            @AuthenticationPrincipal CustomPrincipal principal) {
+        log.info("[PetNoteController] deleteNote noteId={}, userId={}", noteId, principal.getUser().getId());
+        petNoteService.delete(noteId, principal.getUser().getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/converter/PetNoteConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/converter/PetNoteConverter.java
@@ -1,0 +1,29 @@
+package com.newleaseonlife.SafeDogBe.domain.petnote.converter;
+
+import com.newleaseonlife.SafeDogBe.domain.petnote.dto.response.PetNoteResponse;
+import com.newleaseonlife.SafeDogBe.domain.petnote.entity.PetNote;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class PetNoteConverter {
+
+    public PetNoteResponse toResponse(PetNote entity) {
+        return PetNoteResponse.builder()
+                .id(entity.getId())
+                .petId(entity.getPetId())
+                .noteDate(entity.getNoteDate())
+                .content(entity.getContent())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    public List<PetNoteResponse> toResponseList(List<PetNote> entities) {
+        return entities.stream()
+                .map(this::toResponse)
+                .toList();
+    }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/request/PetNoteCreateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/request/PetNoteCreateRequest.java
@@ -1,0 +1,25 @@
+package com.newleaseonlife.SafeDogBe.domain.petnote.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PetNoteCreateRequest {
+
+    @NotNull(message = "반려동물 ID는 필수입니다.")
+    private Long petId;
+
+    @NotNull(message = "기록 날짜는 필수입니다.")
+    private LocalDate noteDate;
+
+    private String content;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/request/PetNoteUpdateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/request/PetNoteUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.newleaseonlife.SafeDogBe.domain.petnote.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PetNoteUpdateRequest {
+
+    private String content;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/response/PetNoteResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/response/PetNoteResponse.java
@@ -1,0 +1,23 @@
+package com.newleaseonlife.SafeDogBe.domain.petnote.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PetNoteResponse {
+
+    private Long id;
+    private Long petId;
+    private LocalDate noteDate;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/entity/PetNote.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/entity/PetNote.java
@@ -1,0 +1,57 @@
+package com.newleaseonlife.SafeDogBe.domain.petnote.entity;
+
+import com.newleaseonlife.SafeDogBe.global.common.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * 날짜별 반려동물 기록 (반려노트).
+ * Pet 1 : N PetNote.
+ *
+ * 추후 연결: Pet 도메인 머지 후 아래를 적용할 예정.
+ * - petId 대신 @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "pet_id") private Pet pet;
+ * - getPetId()는 pet != null ? pet.getId() : null 로 제공하거나, pet 필드로 통일.
+ */
+@Entity
+@Table(name = "pet_notes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PetNote extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 반려동물 ID. 추후 Pet 도메인 머지 시 @ManyToOne Pet pet 로 교체 후 연관관계 매핑 */
+    @Column(name = "pet_id", nullable = false)
+    private Long petId;
+
+    @Column(name = "note_date", nullable = false)
+    private LocalDate noteDate;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Builder
+    public PetNote(Long petId, LocalDate noteDate, String content) {
+        this.petId = petId;
+        this.noteDate = noteDate;
+        this.content = content;
+    }
+
+    public void update(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/repository/PetNoteRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/repository/PetNoteRepository.java
@@ -1,0 +1,25 @@
+package com.newleaseonlife.SafeDogBe.domain.petnote.repository;
+
+import com.newleaseonlife.SafeDogBe.domain.petnote.entity.PetNote;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 추후 연결: Pet 도메인 머지 후, 소유자별 노트 조회가 필요하면
+ * PetRepository.findByUserId()로 내 반려동물 목록 조회 후 petId 목록으로 조회하거나,
+ * PetNote에 @ManyToOne Pet을 두고 PetNoteRepository에 findByPet_UserId(Long userId) 등 추가 가능.
+ */
+public interface PetNoteRepository extends JpaRepository<PetNote, Long> {
+
+    List<PetNote> findAllByPetIdOrderByNoteDateDesc(Long petId);
+
+    List<PetNote> findAllByPetIdAndNoteDateOrderByIdAsc(Long petId, LocalDate noteDate);
+
+    Optional<PetNote> findByIdAndPetId(Long id, Long petId);
+
+    boolean existsByPetId(Long petId);
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/service/PetNoteService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/service/PetNoteService.java
@@ -1,0 +1,99 @@
+package com.newleaseonlife.SafeDogBe.domain.petnote.service;
+
+import com.newleaseonlife.SafeDogBe.domain.petnote.converter.PetNoteConverter;
+import com.newleaseonlife.SafeDogBe.domain.petnote.dto.request.PetNoteCreateRequest;
+import com.newleaseonlife.SafeDogBe.domain.petnote.dto.request.PetNoteUpdateRequest;
+import com.newleaseonlife.SafeDogBe.domain.petnote.dto.response.PetNoteResponse;
+import com.newleaseonlife.SafeDogBe.domain.petnote.entity.PetNote;
+import com.newleaseonlife.SafeDogBe.domain.petnote.repository.PetNoteRepository;
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.PetNoteErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 추후 연결: Pet 도메인 머지 후 아래를 적용할 예정.
+ * - create 시: PetRepository.findById(request.getPetId()) 또는 PetService.findById(petId, userId) 로
+ *   해당 반려동물 존재 여부 및 소유자(userId) 검증 후 저장.
+ * - findById, findByPetId, update, delete 시: 해당 노트의 petId로 Pet 조회 후
+ *   Pet의 소유자(userId)가 현재 로그인 사용자와 일치하는지 검증 (PetService 또는 PetRepository.findByUserId 활용).
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PetNoteService {
+
+    private final PetNoteRepository petNoteRepository;
+    private final PetNoteConverter petNoteConverter;
+
+    public List<PetNoteResponse> findByPetId(Long petId, Long userId) {
+        log.debug("[PetNoteService] findByPetId petId={}, userId={}", petId, userId);
+        // 추후 연결: Pet 도메인 머지 후 해당 petId가 userId 소유인지 검증 (PetService.findById(petId, userId) 등)
+        List<PetNote> notes = petNoteRepository.findAllByPetIdOrderByNoteDateDesc(petId);
+        return petNoteConverter.toResponseList(notes);
+    }
+
+    public List<PetNoteResponse> findByPetIdAndDate(Long petId, LocalDate noteDate, Long userId) {
+        log.debug("[PetNoteService] findByPetIdAndDate petId={}, noteDate={}, userId={}", petId, noteDate, userId);
+        // 추후 연결: Pet 도메인 머지 후 해당 petId가 userId 소유인지 검증
+        List<PetNote> notes = petNoteRepository.findAllByPetIdAndNoteDateOrderByIdAsc(petId, noteDate);
+        return petNoteConverter.toResponseList(notes);
+    }
+
+    public PetNoteResponse findById(Long noteId, Long userId) {
+        log.debug("[PetNoteService] findById noteId={}, userId={}", noteId, userId);
+        PetNote note = getNoteOrThrow(noteId);
+        // 추후 연결: Pet 도메인 머지 후 note.getPetId()에 해당하는 Pet이 userId 소유인지 검증
+        return petNoteConverter.toResponse(note);
+    }
+
+    @Transactional
+    public PetNoteResponse create(PetNoteCreateRequest request, Long userId) {
+        log.info("[PetNoteService] create petId={}, noteDate={}, userId={}",
+                request.getPetId(), request.getNoteDate(), userId);
+        // 추후 연결: Pet 도메인 머지 후 PetRepository.findById(request.getPetId()) 또는
+        // PetService.findById(request.getPetId(), userId) 로 존재 및 소유권 검증
+        PetNote note = PetNote.builder()
+                .petId(request.getPetId())
+                .noteDate(request.getNoteDate())
+                .content(request.getContent())
+                .build();
+        PetNote saved = petNoteRepository.save(note);
+        log.info("[PetNoteService] create 완료 noteId={}", saved.getId());
+        return petNoteConverter.toResponse(saved);
+    }
+
+    @Transactional
+    public PetNoteResponse update(Long noteId, PetNoteUpdateRequest request, Long userId) {
+        log.info("[PetNoteService] update noteId={}, userId={}", noteId, userId);
+        PetNote note = getNoteOrThrow(noteId);
+        // 추후 연결: Pet 도메인 머지 후 note.getPetId()에 해당하는 Pet이 userId 소유인지 검증 후 수정
+        note.update(request.getContent());
+        return petNoteConverter.toResponse(note);
+    }
+
+    @Transactional
+    public void delete(Long noteId, Long userId) {
+        log.info("[PetNoteService] delete noteId={}, userId={}", noteId, userId);
+        PetNote note = getNoteOrThrow(noteId);
+        // 추후 연결: Pet 도메인 머지 후 note.getPetId()에 해당하는 Pet이 userId 소유인지 검증 후 삭제
+        petNoteRepository.delete(note);
+        log.info("[PetNoteService] delete 완료 noteId={}", noteId);
+    }
+
+    private PetNote getNoteOrThrow(Long noteId) {
+        return petNoteRepository.findById(noteId)
+                .orElseThrow(() -> {
+                    log.warn("[PetNoteService] 반려노트 없음 noteId={}", noteId);
+                    return new BusinessException(PetNoteErrorCode.PET_NOTE_NOT_FOUND);
+                });
+    }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/PetNoteErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/PetNoteErrorCode.java
@@ -1,0 +1,25 @@
+package com.newleaseonlife.SafeDogBe.global.error.domain;
+
+import com.newleaseonlife.SafeDogBe.global.error.ApiCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum PetNoteErrorCode implements ApiCode {
+
+    PET_NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "존재하지 않는 반려노트입니다."),
+    PET_NOTE_ACCESS_DENIED(HttpStatus.FORBIDDEN, 403, "해당 반려노트에 접근 권한이 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

날짜별 반려동물 기록을 위한 **반려노트(pet_notes)** 도메인을 신규 구현, 현재 브랜치에는 Pet 도메인이 없어 `petId`(Long)만 사용하며, Pet 도메인 머지 후 연관관계 및 소유권 검증을 연결할 수 있도록 주석으로 표시

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

### 1. Global
- **PetNoteErrorCode** — `PET_NOTE_NOT_FOUND`, `PET_NOTE_ACCESS_DENIED`

### 2. domain.petnote
| 구분 | 파일 | 비고 |
|------|------|------|
| entity | `PetNote.java` | petId, noteDate, content, BaseTimeEntity 상속. 추후 `@ManyToOne Pet` 교체 주석 |
| repository | `PetNoteRepository.java` | petId/날짜별 조회. 추후 소유자별 조회 메서드 추가 가능 주석 |
| dto/request | `PetNoteCreateRequest`, `PetNoteUpdateRequest` | |
| dto/response | `PetNoteResponse` | |
| converter | `PetNoteConverter` | |
| service | `PetNoteService` | CRUD + 날짜별 조회. Pet 연동/소유권 검증 위치 주석 |
| controller | `PetNoteController` | `/api/pet-notes` 엔드포인트 |

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

### 1. API
- `GET /api/pet-notes?petId=` — 반려동물별 노트 목록
- `GET /api/pet-notes/by-date?petId=&noteDate=` — 날짜별 조회
- `GET /api/pet-notes/{noteId}` — 단건 조회
- `POST /api/pet-notes` — 생성
- `PATCH /api/pet-notes/{noteId}` — 수정
- `DELETE /api/pet-notes/{noteId}` — 삭제

### 2. 추후 연결 (Pet 도메인 머지 후)
- `PetNote`: `Long petId` → `@ManyToOne Pet pet` 교체
- `PetNoteService`: create/조회/수정/삭제 시 Pet 존재 여부 및 소유자(userId) 검증 추가
- `PetNoteRepository`: 필요 시 `findByPet_UserId` 등 소유자별 조회 메서드 추가

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
