### PR TITLE
Pet 도메인 - 보호자(PetGuardian) 엔티티·추가/삭제 API 및 주석 보강

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/controller/PetController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/controller/PetController.java
@@ -1,7 +1,9 @@
 package com.newleaseonlife.SafeDogBe.domain.pet.controller;
 
+import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.GuardianAddRequest;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.PetCreateRequest;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.PetUpdateRequest;
+import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetGuardianResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.service.PetService;
 import com.newleaseonlife.SafeDogBe.global.security.CustomPrincipal;
@@ -25,6 +27,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+/**
+ * 반려동물(Pet) API. CRUD 및 보호자(Guardian) 추가·삭제·목록 조회.
+ * 소유자만 수정·삭제·보호자 관리 가능.
+ */
 @Slf4j
 @RestController
 @RequestMapping("/api/pets")
@@ -33,6 +39,7 @@ public class PetController {
 
     private final PetService petService;
 
+    /** 내 반려동물 목록 조회(소유한 Pet만) */
     @GetMapping
     public ResponseEntity<List<PetResponse>> getMyPets(
             @AuthenticationPrincipal CustomPrincipal principal) {
@@ -41,6 +48,7 @@ public class PetController {
         return ResponseEntity.ok(response);
     }
 
+    /** 반려동물 단건 조회. 소유자만 가능 */
     @GetMapping("/{petId}")
     public ResponseEntity<PetResponse> getPet(
             @AuthenticationPrincipal CustomPrincipal principal,
@@ -50,6 +58,7 @@ public class PetController {
         return ResponseEntity.ok(response);
     }
 
+    /** 반려동물 등록. 요청자가 메인 보호자로 저장됨 */
     @PostMapping
     public ResponseEntity<PetResponse> createPet(
             @AuthenticationPrincipal CustomPrincipal principal,
@@ -59,6 +68,7 @@ public class PetController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    /** 반려동물 정보 수정. 소유자만 가능 */
     @PatchMapping("/{petId}")
     public ResponseEntity<PetResponse> updatePet(
             @AuthenticationPrincipal CustomPrincipal principal,
@@ -69,12 +79,46 @@ public class PetController {
         return ResponseEntity.ok(response);
     }
 
+    /** 반려동물 삭제. 소유자만 가능. 보호자 연결(pet_guardian) 함께 삭제 */
     @DeleteMapping("/{petId}")
     public ResponseEntity<Void> deletePet(
             @AuthenticationPrincipal CustomPrincipal principal,
             @PathVariable Long petId) {
         log.info("[PetController] 반려동물 삭제 petId={}, userId={}", petId, principal.getUser().getId());
         petService.delete(petId, principal.getUser().getId());
+        return ResponseEntity.noContent().build();
+    }
+
+    /** 해당 반려동물의 보호자 목록 조회. 소유자만 가능 */
+    @GetMapping("/{petId}/guardians")
+    public ResponseEntity<List<PetGuardianResponse>> getGuardians(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @PathVariable Long petId) {
+        log.info("[PetController] 보호자 목록 조회 petId={}, userId={}", petId, principal.getUser().getId());
+        List<PetGuardianResponse> response = petService.getGuardians(petId, principal.getUser().getId());
+        return ResponseEntity.ok(response);
+    }
+
+    /** 보호자 추가. 소유자만 가능. 이미 등록된 사용자면 409 */
+    @PostMapping("/{petId}/guardians")
+    public ResponseEntity<PetGuardianResponse> addGuardian(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @PathVariable Long petId,
+            @Valid @RequestBody GuardianAddRequest request) {
+        log.info("[PetController] 보호자 추가 petId={}, userId={}", petId, principal.getUser().getId());
+        PetGuardianResponse response = petService.addGuardian(petId, principal.getUser().getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /** 보호자 제거. 소유자만 가능. guardianUserId에 해당하는 보호자 연결만 삭제 */
+    @DeleteMapping("/{petId}/guardians/{guardianUserId}")
+    public ResponseEntity<Void> removeGuardian(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @PathVariable Long petId,
+            @PathVariable Long guardianUserId) {
+        log.info("[PetController] 보호자 제거 petId={}, guardianUserId={}, userId={}",
+                petId, guardianUserId, principal.getUser().getId());
+        petService.removeGuardian(petId, principal.getUser().getId(), guardianUserId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/converter/PetConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/converter/PetConverter.java
@@ -1,15 +1,21 @@
 package com.newleaseonlife.SafeDogBe.domain.pet.converter;
 
+import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetGuardianResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.PetGuardian;
 
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+/**
+ * Pet · PetGuardian 엔티티 → API 응답 DTO 변환.
+ */
 @Component
 public class PetConverter {
 
+    /** Pet → PetResponse. 보호자 목록은 별도 API로 조회 */
     public PetResponse toResponse(Pet pet) {
         return PetResponse.builder()
                 .id(pet.getId())
@@ -29,6 +35,21 @@ public class PetConverter {
     public List<PetResponse> toResponseList(List<Pet> pets) {
         return pets.stream()
                 .map(this::toResponse)
+                .toList();
+    }
+
+    /** PetGuardian → PetGuardianResponse. 보호자 목록·추가 응답에 사용 */
+    public PetGuardianResponse toGuardianResponse(PetGuardian guardian) {
+        return PetGuardianResponse.builder()
+                .id(guardian.getId())
+                .userId(guardian.getUser().getId())
+                .role(guardian.getRole())
+                .build();
+    }
+
+    public List<PetGuardianResponse> toGuardianResponseList(List<PetGuardian> guardians) {
+        return guardians.stream()
+                .map(this::toGuardianResponse)
                 .toList();
     }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/GuardianAddRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/GuardianAddRequest.java
@@ -1,0 +1,29 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.dto.request;
+
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetGuardianRole;
+
+import jakarta.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 보호자 추가 요청. POST /api/pets/{petId}/guardians body.
+ * 반려동물 소유자만 호출 가능.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuardianAddRequest {
+
+    /** 보호자로 등록할 회원 ID */
+    @NotNull(message = "회원 ID는 필수입니다.")
+    private Long userId;
+
+    /** 역할. OWNER(소유자) 또는 CAREGIVER(돌봄이) */
+    @NotNull(message = "역할은 필수입니다.")
+    private PetGuardianRole role;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetCreateRequest.java
@@ -12,6 +12,10 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
+/**
+ * 반려동물 등록 요청. POST /api/pets body.
+ * 요청자는 메인 보호자(pet.user)로 저장됨.
+ */
 @Getter
 @Builder
 @NoArgsConstructor

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetUpdateRequest.java
@@ -11,6 +11,10 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
+/**
+ * 반려동물 수정 요청. PATCH /api/pets/{petId} body.
+ * null 필드는 변경하지 않음(부분 수정).
+ */
 @Getter
 @Builder
 @NoArgsConstructor

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/response/PetGuardianResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/response/PetGuardianResponse.java
@@ -1,0 +1,22 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.dto.response;
+
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetGuardianRole;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 보호자 한 명 응답. GET /api/pets/{petId}/guardians 목록 항목.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PetGuardianResponse {
+
+    private Long id;
+    private Long userId;
+    private PetGuardianRole role;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/response/PetResponse.java
@@ -10,6 +10,10 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+/**
+ * 반려동물 응답. 조회·등록·수정 API 응답에 사용.
+ * 보호자 목록은 GET /api/pets/{petId}/guardians 로 별도 조회.
+ */
 @Getter
 @Builder
 @NoArgsConstructor

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/Pet.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/Pet.java
@@ -3,6 +3,7 @@ package com.newleaseonlife.SafeDogBe.domain.pet.entity;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
 import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -14,6 +15,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import lombok.AccessLevel;
@@ -27,7 +29,13 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+/**
+ * 반려동물 엔티티. 메인 보호자(user)와 보호자 목록(guardians)을 가짐.
+ * Pet 삭제 시 guardians는 cascade + orphanRemoval로 함께 삭제됨.
+ */
 @Entity
 @Table(name = "pets")
 @Getter
@@ -39,9 +47,14 @@ public class Pet {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /** 메인 보호자(소유자). pets.user_id */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    /** 보호자 목록(OWNER, CAREGIVER). Pet 삭제 시 함께 삭제, guardian 제거 시 DB에서도 삭제(orphanRemoval) */
+    @OneToMany(mappedBy = "pet", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PetGuardian> guardians = new ArrayList<>();
 
     @Column(nullable = false, length = 100)
     private String name;
@@ -84,6 +97,7 @@ public class Pet {
         this.profileImageUrl = profileImageUrl;
     }
 
+    /** 정보 수정. null이 아닌 필드만 반영 */
     public void update(String name, String species, String breed, LocalDate birthDate,
                        Gender gender, Boolean isNeutered, String profileImageUrl) {
         if (name != null) this.name = name;

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/PetGuardian.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/PetGuardian.java
@@ -1,0 +1,62 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.entity;
+
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetGuardianRole;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 반려동물-보호자 연결. 한 반려동물에 여러 보호자(OWNER, CAREGIVER) 지정 가능.
+ * Pet 엔티티에서 @OneToMany(guardians)로 역방향 참조.
+ */
+@Entity
+@Table(
+        name = "pet_guardian",
+        uniqueConstraints = @UniqueConstraint(name = "uk_pet_guardian_user_pet", columnNames = {"user_id", "pet_id"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PetGuardian {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** 보호자로 등록된 회원 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /** 대상 반려동물. Pet.guardians와 양방향 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", nullable = false)
+    private Pet pet;
+
+    /** 역할. OWNER 또는 CAREGIVER */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    private PetGuardianRole role;
+
+    @Builder
+    public PetGuardian(User user, Pet pet, PetGuardianRole role) {
+        this.user = user;
+        this.pet = pet;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/enums/Gender.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/enums/Gender.java
@@ -1,5 +1,6 @@
 package com.newleaseonlife.SafeDogBe.domain.pet.entity.enums;
 
+/** 반려동물 성별. Pet 엔티티 gender 컬럼 */
 public enum Gender {
     MALE,
     FEMALE

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/enums/PetGuardianRole.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/enums/PetGuardianRole.java
@@ -1,0 +1,9 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.entity.enums;
+
+/** 반려동물 보호자 역할. pet_guardian 테이블 role 컬럼 */
+public enum PetGuardianRole {
+    /** 소유자(메인 보호자) */
+    OWNER,
+    /** 돌봄이(공동 보호자) */
+    CAREGIVER
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/repository/PetGuardianRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/repository/PetGuardianRepository.java
@@ -1,0 +1,24 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.repository;
+
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.PetGuardian;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 반려동물-보호자(pet_guardian) 영속화.
+ * Pet 소유자만 추가/삭제 가능하므로, 서비스에서 소유권 검사 후 사용.
+ */
+public interface PetGuardianRepository extends JpaRepository<PetGuardian, Long> {
+
+    /** 해당 반려동물의 보호자 목록 조회 */
+    List<PetGuardian> findByPetIdOrderByIdAsc(Long petId);
+
+    /** 특정 반려동물·사용자 조합의 보호자 연결 조회 */
+    Optional<PetGuardian> findByPetIdAndUserId(Long petId, Long userId);
+
+    /** 특정 반려동물에 해당 사용자가 보호자로 등록되어 있는지 여부 */
+    boolean existsByPetIdAndUserId(Long petId, Long userId);
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/repository/PetRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/repository/PetRepository.java
@@ -7,11 +7,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * 반려동물(Pet) 영속화. 메인 보호자(user_id) 기준 조회·존재 여부 확인.
+ */
 public interface PetRepository extends JpaRepository<Pet, Long> {
 
+    /** 메인 보호자 기준 내 반려동물 목록(최신순) */
     List<Pet> findAllByUserIdOrderByCreatedAtDesc(Long userId);
 
+    /** ID + 메인 보호자로 단건 조회. 소유자만 조회 시 사용 */
     Optional<Pet> findByIdAndUserId(Long id, Long userId);
 
+    /** 해당 반려동물이 해당 사용자 소유인지 여부 */
     boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/service/PetService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/service/PetService.java
@@ -1,10 +1,14 @@
 package com.newleaseonlife.SafeDogBe.domain.pet.service;
 
+import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.GuardianAddRequest;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.PetCreateRequest;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.PetUpdateRequest;
+import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetGuardianResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.PetGuardian;
 import com.newleaseonlife.SafeDogBe.domain.pet.converter.PetConverter;
+import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetGuardianRepository;
 import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetRepository;
 import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
 import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
@@ -20,6 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+/**
+ * 반려동물(Pet) 도메인 서비스. CRUD, 보호자(Guardian) 추가·삭제·목록 조회.
+ * 반려동물 소유자(pet.user)만 수정·삭제·보호자 관리 가능.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -27,15 +35,18 @@ import java.util.List;
 public class PetService {
 
     private final PetRepository petRepository;
+    private final PetGuardianRepository petGuardianRepository;
     private final UserRepository userRepository;
     private final PetConverter petConverter;
 
+    /** 내가 소유한 반려동물 목록(최신순) */
     public List<PetResponse> findMyPets(Long userId) {
         log.debug("[PetService] findMyPets userId={}", userId);
         List<Pet> pets = petRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
         return petConverter.toResponseList(pets);
     }
 
+    /** 반려동물 단건 조회. 소유자만 조회 가능(보호자 목록 포함 조회는 getGuardians 사용) */
     public PetResponse findById(Long petId, Long userId) {
         log.debug("[PetService] findById petId={}, userId={}", petId, userId);
         Pet pet = petRepository.findByIdAndUserId(petId, userId)
@@ -48,6 +59,7 @@ public class PetService {
         return petConverter.toResponse(pet);
     }
 
+    /** 반려동물 등록. 요청자를 메인 보호자(pet.user)로 저장 */
     @Transactional
     public PetResponse create(Long userId, PetCreateRequest request) {
         log.info("[PetService] create userId={}, name={}", userId, request.getName());
@@ -70,6 +82,7 @@ public class PetService {
         return petConverter.toResponse(pet);
     }
 
+    /** 반려동물 정보 수정. 소유자만 가능 */
     @Transactional
     public PetResponse update(Long petId, Long userId, PetUpdateRequest request) {
         log.info("[PetService] update petId={}, userId={}", petId, userId);
@@ -94,6 +107,7 @@ public class PetService {
         return petConverter.toResponse(pet);
     }
 
+    /** 반려동물 삭제. 소유자만 가능. pet_guardian 행은 cascade로 함께 삭제 */
     @Transactional
     public void delete(Long petId, Long userId) {
         log.info("[PetService] delete petId={}, userId={}", petId, userId);
@@ -105,5 +119,61 @@ public class PetService {
         }
         petRepository.deleteById(petId);
         log.info("[PetService] delete 완료 petId={}", petId);
+    }
+
+    /** 해당 반려동물의 보호자 목록 조회. 소유자만 호출 가능 */
+    public List<PetGuardianResponse> getGuardians(Long petId, Long userId) {
+        log.debug("[PetService] getGuardians petId={}, userId={}", petId, userId);
+        Pet pet = getPetAsOwnerOrThrow(petId, userId);
+        List<PetGuardian> guardians = petGuardianRepository.findByPetIdOrderByIdAsc(pet.getId());
+        return petConverter.toGuardianResponseList(guardians);
+    }
+
+    /** 보호자 추가. 소유자만 가능. 이미 등록된 사용자면 PET_GUARDIAN_ALREADY_EXISTS */
+    @Transactional
+    public PetGuardianResponse addGuardian(Long petId, Long ownerUserId, GuardianAddRequest request) {
+        log.info("[PetService] addGuardian petId={}, ownerUserId={}, targetUserId={}, role={}",
+                petId, ownerUserId, request.getUserId(), request.getRole());
+        Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
+        User targetUser = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+        if (petGuardianRepository.existsByPetIdAndUserId(pet.getId(), request.getUserId())) {
+            log.warn("[PetService] addGuardian 실패 - 이미 보호자로 등록됨 petId={}, userId={}", petId, request.getUserId());
+            throw new BusinessException(PetErrorCode.PET_GUARDIAN_ALREADY_EXISTS);
+        }
+        PetGuardian guardian = PetGuardian.builder()
+                .user(targetUser)
+                .pet(pet)
+                .role(request.getRole())
+                .build();
+        pet.getGuardians().add(guardian);
+        PetGuardian saved = petGuardianRepository.save(guardian);
+        log.info("[PetService] addGuardian 완료 guardianId={}", saved.getId());
+        return petConverter.toGuardianResponse(saved);
+    }
+
+    /** 보호자 제거. 소유자만 가능. 지정한 userId의 보호자 연결만 삭제 */
+    @Transactional
+    public void removeGuardian(Long petId, Long ownerUserId, Long guardianUserId) {
+        log.info("[PetService] removeGuardian petId={}, ownerUserId={}, guardianUserId={}", petId, ownerUserId, guardianUserId);
+        Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
+        PetGuardian guardian = petGuardianRepository.findByPetIdAndUserId(pet.getId(), guardianUserId)
+                .orElseThrow(() -> {
+                    log.warn("[PetService] removeGuardian 실패 - 보호자 없음 petId={}, userId={}", petId, guardianUserId);
+                    return new BusinessException(PetErrorCode.PET_GUARDIAN_NOT_FOUND);
+                });
+        pet.getGuardians().remove(guardian);
+        log.info("[PetService] removeGuardian 완료 guardianId={} (orphanRemoval)", guardian.getId());
+    }
+
+    /** 반려동물 조회(소유자만). 없거나 권한 없으면 예외 */
+    private Pet getPetAsOwnerOrThrow(Long petId, Long userId) {
+        return petRepository.findByIdAndUserId(petId, userId)
+                .orElseThrow(() -> {
+                    if (petRepository.findById(petId).isEmpty()) {
+                        return new BusinessException(PetErrorCode.PET_NOT_FOUND);
+                    }
+                    return new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
+                });
     }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/PetErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/PetErrorCode.java
@@ -12,7 +12,11 @@ import org.springframework.http.HttpStatus;
 public enum PetErrorCode implements ApiCode {
 
     PET_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "존재하지 않는 반려동물입니다."),
-    PET_ACCESS_DENIED(HttpStatus.FORBIDDEN, 403, "해당 반려동물에 접근 권한이 없습니다.");
+    PET_ACCESS_DENIED(HttpStatus.FORBIDDEN, 403, "해당 반려동물에 접근 권한이 없습니다."),
+    /** 동일 반려동물에 이미 등록된 보호자 */
+    PET_GUARDIAN_ALREADY_EXISTS(HttpStatus.CONFLICT, 409, "이미 해당 반려동물의 보호자로 등록된 사용자입니다."),
+    /** 보호자 연결 없음(삭제 대상 없음) */
+    PET_GUARDIAN_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "등록된 보호자 정보를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#29 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

- **Pet ↔ PetGuardian**: Pet에 `@OneToMany(guardians)` 추가 (cascade, orphanRemoval). PetGuardian 엔티티·PetGuardianRole enum 신규.
- **보호자 API**: GET/POST/DELETE `/api/pets/{petId}/guardians`(·`/{guardianUserId}`). 소유자만 호출 가능.
- **도메인 주석**: Pet, PetGuardian, Repository, Service, Controller, DTO, Converter 전반 주석 추가.

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

### 1. 엔티티·Enum
- **Pet**: `List<PetGuardian> guardians` OneToMany 추가. 클래스·필드·update() 주석.
- **PetGuardian**: 신규. user, pet, role. uk_pet_guardian_user_pet.
- **PetGuardianRole**: OWNER, CAREGIVER.

### 2. Repository·에러코드
- **PetGuardianRepository**: findByPetIdOrderByIdAsc, findByPetIdAndUserId, existsByPetIdAndUserId.
- **PetErrorCode**: PET_GUARDIAN_ALREADY_EXISTS, PET_GUARDIAN_NOT_FOUND.

### 3. DTO·Converter
- **GuardianAddRequest**: userId, role (POST body).
- **PetGuardianResponse**: id, userId, role.
- **PetConverter**: toGuardianResponse, toGuardianResponseList.

### 4. Service·Controller
- **PetService**: getGuardians, addGuardian, removeGuardian, getPetAsOwnerOrThrow. 기존 메서드·클래스 주석.
- **PetController**: GET/POST/DELETE guardians 3개 엔드포인트. 기존 엔드포인트 주석.

### 5. 기타 주석
- PetRepository, PetCreateRequest, PetUpdateRequest, PetResponse, Gender 등 클래스·용도 주석.

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
