### PR TITLE
PetNote 도메인 - @ManyToOne Pet 연관관계·소유권 검증·update(noteDate)·도메인 주석

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/controller/PetNoteController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/controller/PetNoteController.java
@@ -29,9 +29,8 @@ import java.time.LocalDate;
 import java.util.List;
 
 /**
- * 반려노트 API.
- * 추후 연결: Pet 도메인 머지 후, petId에 대한 소유권 검증이 서비스 계층에서 이루어지므로
- * 동일한 엔드포인트를 유지하면서 보안만 강화하면 됨.
+ * 반려노트(PetNote) API. CRUD 및 날짜별 조회.
+ * 소유권 검증은 서비스 계층에서 수행(해당 Pet의 소유자만 조회·생성·수정·삭제 가능).
  */
 @Slf4j
 @RestController

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/converter/PetNoteConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/converter/PetNoteConverter.java
@@ -7,9 +7,13 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+/**
+ * PetNote 엔티티 → PetNoteResponse 변환. API 응답 DTO 생성 시 사용.
+ */
 @Component
 public class PetNoteConverter {
 
+    /** 엔티티를 응답 DTO로 변환. petId는 getPetId() 편의 메서드로 조회 */
     public PetNoteResponse toResponse(PetNote entity) {
         return PetNoteResponse.builder()
                 .id(entity.getId())
@@ -21,6 +25,7 @@ public class PetNoteConverter {
                 .build();
     }
 
+    /** 엔티티 목록을 응답 DTO 목록으로 변환 */
     public List<PetNoteResponse> toResponseList(List<PetNote> entities) {
         return entities.stream()
                 .map(this::toResponse)

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/request/PetNoteCreateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/request/PetNoteCreateRequest.java
@@ -9,17 +9,24 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
+/**
+ * 반려노트 등록 요청. POST /api/pet-notes body.
+ * petId에 해당하는 Pet 소유자만 생성 가능.
+ */
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class PetNoteCreateRequest {
 
+    /** 대상 반려동물 ID. 소유자 검증 후 Pet 엔티티로 매핑 */
     @NotNull(message = "반려동물 ID는 필수입니다.")
     private Long petId;
 
+    /** 기록 대상일 */
     @NotNull(message = "기록 날짜는 필수입니다.")
     private LocalDate noteDate;
 
+    /** 메모 내용. 선택 */
     private String content;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/request/PetNoteUpdateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/request/PetNoteUpdateRequest.java
@@ -5,11 +5,21 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
+/**
+ * 반려노트 수정 요청. PATCH /api/pet-notes/{noteId} body.
+ * null 필드는 변경하지 않음(부분 수정).
+ */
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class PetNoteUpdateRequest {
 
+    /** 수정할 메모 내용 */
     private String content;
+
+    /** 수정할 기록일. 날짜 변경 시 사용 */
+    private LocalDate noteDate;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/response/PetNoteResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/response/PetNoteResponse.java
@@ -8,6 +8,9 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
+/**
+ * 반려노트 응답. 조회·등록·수정 API 응답에 사용.
+ */
 @Getter
 @Builder
 @NoArgsConstructor

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/entity/PetNote.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/entity/PetNote.java
@@ -1,12 +1,17 @@
 package com.newleaseonlife.SafeDogBe.domain.petnote.entity;
 
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
 import com.newleaseonlife.SafeDogBe.global.common.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 import lombok.AccessLevel;
@@ -17,12 +22,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 
 /**
- * 날짜별 반려동물 기록 (반려노트).
- * Pet 1 : N PetNote.
- *
- * 추후 연결: Pet 도메인 머지 후 아래를 적용할 예정.
- * - petId 대신 @ManyToOne(fetch = FetchType.LAZY) @JoinColumn(name = "pet_id") private Pet pet;
- * - getPetId()는 pet != null ? pet.getId() : null 로 제공하거나, pet 필드로 통일.
+ * 날짜별 반려동물 기록 (반려노트). Pet 1 : N PetNote.
  */
 @Entity
 @Table(name = "pet_notes")
@@ -34,24 +34,34 @@ public class PetNote extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /** 반려동물 ID. 추후 Pet 도메인 머지 시 @ManyToOne Pet pet 로 교체 후 연관관계 매핑 */
-    @Column(name = "pet_id", nullable = false)
-    private Long petId;
+    /** 대상 반려동물. FK 이름 fk_pet_notes_pet */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", nullable = false, foreignKey = @ForeignKey(name = "fk_pet_notes_pet"))
+    private Pet pet;
 
+    /** 기록 대상일. 날짜별 조회에 사용 */
     @Column(name = "note_date", nullable = false)
     private LocalDate noteDate;
 
+    /** 메모 내용. TEXT 타입 */
     @Column(columnDefinition = "TEXT")
     private String content;
 
     @Builder
-    public PetNote(Long petId, LocalDate noteDate, String content) {
-        this.petId = petId;
+    public PetNote(Pet pet, LocalDate noteDate, String content) {
+        this.pet = pet;
         this.noteDate = noteDate;
         this.content = content;
     }
 
-    public void update(String content) {
-        this.content = content;
+    /** 편의 메서드: petId가 필요한 경우를 위해 제공 */
+    public Long getPetId() {
+        return pet != null ? pet.getId() : null;
+    }
+
+    /** 내용·기록일 수정. null이 아닌 값만 반영 */
+    public void update(String content, LocalDate noteDate) {
+        if (content != null) this.content = content;
+        if (noteDate != null) this.noteDate = noteDate;
     }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/repository/PetNoteRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/repository/PetNoteRepository.java
@@ -9,17 +9,19 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * 추후 연결: Pet 도메인 머지 후, 소유자별 노트 조회가 필요하면
- * PetRepository.findByUserId()로 내 반려동물 목록 조회 후 petId 목록으로 조회하거나,
- * PetNote에 @ManyToOne Pet을 두고 PetNoteRepository에 findByPet_UserId(Long userId) 등 추가 가능.
+ * 반려노트(pet_notes) 영속화. Pet 연관관계 기준 조회.
  */
 public interface PetNoteRepository extends JpaRepository<PetNote, Long> {
 
-    List<PetNote> findAllByPetIdOrderByNoteDateDesc(Long petId);
+    /** 해당 반려동물의 노트 목록. 날짜 최신순 */
+    List<PetNote> findAllByPet_IdOrderByNoteDateDesc(Long petId);
 
-    List<PetNote> findAllByPetIdAndNoteDateOrderByIdAsc(Long petId, LocalDate noteDate);
+    /** 해당 반려동물·특정일의 노트 목록. 날짜별 조회용 */
+    List<PetNote> findAllByPet_IdAndNoteDateOrderByIdAsc(Long petId, LocalDate noteDate);
 
-    Optional<PetNote> findByIdAndPetId(Long id, Long petId);
+    /** ID + petId로 단건 조회 */
+    Optional<PetNote> findByIdAndPet_Id(Long id, Long petId);
 
-    boolean existsByPetId(Long petId);
+    /** 해당 반려동물에 노트 존재 여부 */
+    boolean existsByPet_Id(Long petId);
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/service/PetNoteService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/service/PetNoteService.java
@@ -1,5 +1,7 @@
 package com.newleaseonlife.SafeDogBe.domain.petnote.service;
 
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetRepository;
 import com.newleaseonlife.SafeDogBe.domain.petnote.converter.PetNoteConverter;
 import com.newleaseonlife.SafeDogBe.domain.petnote.dto.request.PetNoteCreateRequest;
 import com.newleaseonlife.SafeDogBe.domain.petnote.dto.request.PetNoteUpdateRequest;
@@ -7,6 +9,7 @@ import com.newleaseonlife.SafeDogBe.domain.petnote.dto.response.PetNoteResponse;
 import com.newleaseonlife.SafeDogBe.domain.petnote.entity.PetNote;
 import com.newleaseonlife.SafeDogBe.domain.petnote.repository.PetNoteRepository;
 import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.PetErrorCode;
 import com.newleaseonlife.SafeDogBe.global.error.domain.PetNoteErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -19,11 +22,8 @@ import java.time.LocalDate;
 import java.util.List;
 
 /**
- * 추후 연결: Pet 도메인 머지 후 아래를 적용할 예정.
- * - create 시: PetRepository.findById(request.getPetId()) 또는 PetService.findById(petId, userId) 로
- *   해당 반려동물 존재 여부 및 소유자(userId) 검증 후 저장.
- * - findById, findByPetId, update, delete 시: 해당 노트의 petId로 Pet 조회 후
- *   Pet의 소유자(userId)가 현재 로그인 사용자와 일치하는지 검증 (PetService 또는 PetRepository.findByUserId 활용).
+ * 반려노트(PetNote) 도메인 서비스. CRUD 및 날짜별 조회.
+ * create/조회/수정/삭제 시 해당 Pet의 소유자(userId) 검증 후 처리.
  */
 @Slf4j
 @Service
@@ -32,37 +32,47 @@ import java.util.List;
 public class PetNoteService {
 
     private final PetNoteRepository petNoteRepository;
+    private final PetRepository petRepository;
     private final PetNoteConverter petNoteConverter;
 
+    /** 반려동물별 노트 목록(날짜 최신순). 소유자만 조회 가능 */
     public List<PetNoteResponse> findByPetId(Long petId, Long userId) {
         log.debug("[PetNoteService] findByPetId petId={}, userId={}", petId, userId);
-        // 추후 연결: Pet 도메인 머지 후 해당 petId가 userId 소유인지 검증 (PetService.findById(petId, userId) 등)
-        List<PetNote> notes = petNoteRepository.findAllByPetIdOrderByNoteDateDesc(petId);
+        ensurePetOwnership(petId, userId);
+        List<PetNote> notes = petNoteRepository.findAllByPet_IdOrderByNoteDateDesc(petId);
         return petNoteConverter.toResponseList(notes);
     }
 
+    /** 반려동물·특정일 노트 목록(날짜별 조회). 소유자만 조회 가능 */
     public List<PetNoteResponse> findByPetIdAndDate(Long petId, LocalDate noteDate, Long userId) {
         log.debug("[PetNoteService] findByPetIdAndDate petId={}, noteDate={}, userId={}", petId, noteDate, userId);
-        // 추후 연결: Pet 도메인 머지 후 해당 petId가 userId 소유인지 검증
-        List<PetNote> notes = petNoteRepository.findAllByPetIdAndNoteDateOrderByIdAsc(petId, noteDate);
+        ensurePetOwnership(petId, userId);
+        List<PetNote> notes = petNoteRepository.findAllByPet_IdAndNoteDateOrderByIdAsc(petId, noteDate);
         return petNoteConverter.toResponseList(notes);
     }
 
+    /** 노트 단건 조회. 해당 노트의 Pet 소유자만 가능 */
     public PetNoteResponse findById(Long noteId, Long userId) {
         log.debug("[PetNoteService] findById noteId={}, userId={}", noteId, userId);
         PetNote note = getNoteOrThrow(noteId);
-        // 추후 연결: Pet 도메인 머지 후 note.getPetId()에 해당하는 Pet이 userId 소유인지 검증
+        ensurePetOwnership(note.getPetId(), userId);
         return petNoteConverter.toResponse(note);
     }
 
+    /** 반려노트 생성. request.petId에 해당하는 Pet 소유자만 가능 */
     @Transactional
     public PetNoteResponse create(PetNoteCreateRequest request, Long userId) {
         log.info("[PetNoteService] create petId={}, noteDate={}, userId={}",
                 request.getPetId(), request.getNoteDate(), userId);
-        // 추후 연결: Pet 도메인 머지 후 PetRepository.findById(request.getPetId()) 또는
-        // PetService.findById(request.getPetId(), userId) 로 존재 및 소유권 검증
+        Pet pet = petRepository.findByIdAndUserId(request.getPetId(), userId)
+                .orElseThrow(() -> {
+                    if (petRepository.findById(request.getPetId()).isEmpty()) {
+                        return new BusinessException(PetErrorCode.PET_NOT_FOUND);
+                    }
+                    return new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
+                });
         PetNote note = PetNote.builder()
-                .petId(request.getPetId())
+                .pet(pet)
                 .noteDate(request.getNoteDate())
                 .content(request.getContent())
                 .build();
@@ -71,29 +81,43 @@ public class PetNoteService {
         return petNoteConverter.toResponse(saved);
     }
 
+    /** 반려노트 수정. content·noteDate 중 전달된 값만 반영. 소유자만 가능 */
     @Transactional
     public PetNoteResponse update(Long noteId, PetNoteUpdateRequest request, Long userId) {
         log.info("[PetNoteService] update noteId={}, userId={}", noteId, userId);
         PetNote note = getNoteOrThrow(noteId);
-        // 추후 연결: Pet 도메인 머지 후 note.getPetId()에 해당하는 Pet이 userId 소유인지 검증 후 수정
-        note.update(request.getContent());
+        ensurePetOwnership(note.getPetId(), userId);
+        note.update(request.getContent(), request.getNoteDate());
         return petNoteConverter.toResponse(note);
     }
 
+    /** 반려노트 삭제. 해당 노트의 Pet 소유자만 가능 */
     @Transactional
     public void delete(Long noteId, Long userId) {
         log.info("[PetNoteService] delete noteId={}, userId={}", noteId, userId);
         PetNote note = getNoteOrThrow(noteId);
-        // 추후 연결: Pet 도메인 머지 후 note.getPetId()에 해당하는 Pet이 userId 소유인지 검증 후 삭제
+        ensurePetOwnership(note.getPetId(), userId);
         petNoteRepository.delete(note);
         log.info("[PetNoteService] delete 완료 noteId={}", noteId);
     }
 
+    /** 노트 조회. 없으면 PET_NOTE_NOT_FOUND */
     private PetNote getNoteOrThrow(Long noteId) {
         return petNoteRepository.findById(noteId)
                 .orElseThrow(() -> {
                     log.warn("[PetNoteService] 반려노트 없음 noteId={}", noteId);
                     return new BusinessException(PetNoteErrorCode.PET_NOTE_NOT_FOUND);
                 });
+    }
+
+    /** 해당 반려동물이 현재 사용자 소유인지 검증. 아니면 PET_NOT_FOUND 또는 PET_ACCESS_DENIED */
+    private void ensurePetOwnership(Long petId, Long userId) {
+        if (petId == null) return;
+        if (!petRepository.existsByIdAndUserId(petId, userId)) {
+            if (petRepository.findById(petId).isEmpty()) {
+                throw new BusinessException(PetErrorCode.PET_NOT_FOUND);
+            }
+            throw new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
+        }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#37 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

- **PetNote**: `Long petId` → `@ManyToOne Pet pet`, FK 이름 `fk_pet_notes_pet`, `getPetId()` 편의 메서드, `update(content, noteDate)`.
- **소유권 검증**: create/조회/수정/삭제 시 해당 Pet 소유자만 가능하도록 PetRepository 활용.
- **도메인 주석**: PetNote, Repository, Service, Controller, Converter, DTO 전반 주석 추가.

## 🛠️ 주요 변경 사항 및 리팩토링

### 1. PetNote 엔티티
- `@ManyToOne(fetch = LAZY) Pet pet` + `@JoinColumn(foreignKey = @ForeignKey(name = "fk_pet_notes_pet"))`
- Builder: `PetNote(Pet pet, LocalDate noteDate, String content)`
- `getPetId()`, `update(String content, LocalDate noteDate)`

### 2. PetNoteRepository
- 메서드명: `findAllByPet_IdOrderByNoteDateDesc`, `findAllByPet_IdAndNoteDateOrderByIdAsc`, `findByIdAndPet_Id`, `existsByPet_Id`

### 3. PetNoteService
- PetRepository 주입. create 시 `findByIdAndUserId`로 Pet 조회 후 `PetNote.builder().pet(pet)...`
- `ensurePetOwnership(petId, userId)` 로 조회·수정·삭제 전 소유자 검증
- update: `note.update(request.getContent(), request.getNoteDate())`

### 4. DTO
- PetNoteUpdateRequest: `noteDate` 필드 추가

### 5. 주석
- PetNote, PetNoteRepository, PetNoteService, PetNoteController, PetNoteConverter, PetNoteCreateRequest, PetNoteUpdateRequest, PetNoteResponse 클래스·메서드·필드 주석

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

- Pet 도메인(domain.pet)에 의존