### PR TITLE
Term 도메인 - UserTerm 엔티티 제약·FK 이름·컬럼명·주석 보강

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/entity/UserTerm.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/entity/UserTerm.java
@@ -5,6 +5,7 @@ import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,9 +21,19 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+/**
+ * 회원-약관 동의 내역 엔티티.
+ * (user_id, term_id) 유니크로 한 사용자당 약관별 동의 이력 1건.
+ * agreedAt은 동의 시각(동의 시에만 기록).
+ */
 @Entity
-@Table(name = "user_terms",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "term_id"}))
+@Table(
+        name = "user_terms",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_terms_user_term",
+                columnNames = {"user_id", "term_id"}
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserTerm {
@@ -32,16 +43,25 @@ public class UserTerm {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_user_terms_user")
+    )
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "term_id", nullable = false)
+    @JoinColumn(
+            name = "term_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_user_terms_term")
+    )
     private Term term;
 
     @Column(nullable = false)
-    private boolean agreed;
+    private boolean agreed = false;
 
+    @Column(name = "agreed_at")
     private LocalDateTime agreedAt;
 
     @Builder
@@ -52,6 +72,7 @@ public class UserTerm {
         this.agreedAt = agreed ? LocalDateTime.now() : null;
     }
 
+    /** 동의 여부 변경. agreed true 시 agreedAt을 현재 시각으로 설정, false 시 null. */
     public void updateAgreed(boolean agreed) {
         this.agreed = agreed;
         this.agreedAt = agreed ? LocalDateTime.now() : null;


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#39 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) 
> e.g. Board 관련 DTO 구현 (생성/응답) 
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

Term 도메인 **UserTerm** 엔티티에 유니크 제약/FK 이름, `agreed_at` 컬럼명, Javadoc 주석을 반영했습니다. API·서비스·리포지토리 동작 변경은 없음.

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

| 항목 | 내용 |
|------|------|
| **@Table** | `uniqueConstraints` 이름 `uk_user_terms_user_term` 지정 |
| **@JoinColumn(user)** | `foreignKey = @ForeignKey(name = "fk_user_terms_user")` |
| **@JoinColumn(term)** | `foreignKey = @ForeignKey(name = "fk_user_terms_term")` |
| **agreed** | 기본값 `false` 명시 (`private boolean agreed = false`) |
| **agreedAt** | `@Column(name = "agreed_at")` 로 컬럼명 명시 |
| **주석** | UserTerm 클래스·`updateAgreed(boolean)` Javadoc 추가 |

**수정 파일:** `domain/term/entity/UserTerm.java`  
**미수정:** TermService, UserTermRepository, TermController (변경 없음)

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

- API·서비스 로직 변경 없음. DDL/스키마 문서화·운영 시 제약·FK 식별에 유리