### PR TITLE
[feat]: care,aws s3 도메인 개발 (#33, #35, #36, #41)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,9 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.2'
+    id 'org.springframework.boot' version '3.4.2'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
+    id 'com.google.cloud.tools.jib' version '3.4.1'
 }
 
 group = 'com.newleaseonlife'
@@ -10,7 +12,7 @@ description = '동네 기반 반려동물 정보 공유 커뮤니티 서비스'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(17) // Spring Boot 3.x의 가상 스레드 활용을 위해 Java 21 권장
     }
 }
 
@@ -23,6 +25,7 @@ configurations {
 repositories {
     mavenCentral()
 }
+
 dependencies {
     // 1. Web & Real-time
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -32,40 +35,72 @@ dependencies {
     // 2. Security & Auth (OAuth2 + JWT)
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    // JWT를 다루기 위한 JJWT 라이브러리 (버전 0.11.5)
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
-    // 3. Database (JPA + MySQL + H2)
+    // 3. Database (JPA + MySQL/MariaDB + H2 + DB Migration)
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
 
     // 4. Redis (Caching & Distributed Lock)
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson:3.27.0'
 
-    // 5. Location (Spatial Data)
+    // 5. Location (Spatial Data - 동네 기반 서비스용)
     implementation 'org.hibernate.orm:hibernate-spatial'
     implementation 'org.locationtech.jts:jts-core:1.19.0'
 
-    // 6. API Documentation (Swagger)
+    // 6. Monitoring & CI/CD
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // 7. API Documentation (Swagger)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11'
 
-    // 7. Utils
+    // 8. Utils
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    implementation 'org.apache.commons:commons-lang3:3.20.0' //UUID 보다 Lang이 더 좋은거 같음. 가독성이
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310' //레디스 <-> RDB로 형변환 할때 시켜주는 도구
+    implementation 'org.apache.commons:commons-lang3:3.14.0' // 안전한 최신 안정 버전으로 조정
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
-    // 8. Testing
+    // 9. Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.assertj:assertj-core'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // 10.AWS S3 연동을 위한 SDK
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.696'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport' // 테스트 종료 후 자동으로 커버리지 리포트 생성
+}
+
+jacocoTestReport {
+    dependsOn test
+}
+
+// Jib 설정: Github Actions에서 빌드 후 DockerHub/ECR로 푸시
+jib {
+    from {
+        image = 'eclipse-temurin:21-jre-alpine' // 경량화된 Alpine 리눅스 기반 JRE 21 사용
+    }
+    to {
+        image = '237245538374.dkr.ecr.ap-northeast-2.amazonaws.com/my-spring-boot-app_2_13' // ECR 주소 또는 DockerHub 주소
+        tags = ['latest', "${project.version}".toString()]
+    }
+    container {
+        // 컨테이너 메모리 최적화 및 타임존 설정
+        jvmFlags = ['-Xms256m', '-Xmx512m', '-Djava.security.egd=file:/dev/./urandom']
+        environment = [TZ: "Asia/Seoul"]
+        ports = ['8080']
+    }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/SafeDogBeApplication.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/SafeDogBeApplication.java
@@ -3,13 +3,23 @@ package com.newleaseonlife.SafeDogBe;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@EnableScheduling // ★ 배치 스케줄러 활성화 ★
 @EnableJpaAuditing
+@SpringBootApplication
 public class SafeDogBeApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(SafeDogBeApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(SafeDogBeApplication.class, args);
+    System.out.println("\n" +
+        "=================================================\n" +
+        "🚀 Shared ToDo Application 시작 완료!\n" +
+        "=================================================\n" +
+        "📋 Swagger UI: http://localhost:8080/swagger-ui/index.html\n" +
+        "⭐ JPA Auditing 적용: 자동 시간/사용자 추적\n" +
+        "=================================================\n");
+  }
+
 
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/CareTemplateController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/CareTemplateController.java
@@ -1,0 +1,31 @@
+package com.newleaseonlife.SafeDogBe.domain.care.controller;
+
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.CareTemplateCreateRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.CareTemplateResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.service.CareTemplateService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/care-templates")
+public class CareTemplateController {
+
+  private final CareTemplateService careTemplateService;
+
+  @PostMapping
+  public ResponseEntity<CareTemplateResponse> createTemplate(@Valid @RequestBody CareTemplateCreateRequest request) {
+    CareTemplateResponse response = careTemplateService.createTemplate(request);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+  @DeleteMapping("/{templateId}")
+  public ResponseEntity<Void> deactivateTemplate(@PathVariable Long templateId) {
+    careTemplateService.deactivateTemplate(templateId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/DailyChecklistController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/DailyChecklistController.java
@@ -1,0 +1,34 @@
+package com.newleaseonlife.SafeDogBe.domain.care.controller;
+
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.DailyChecklistResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.service.DailyChecklistService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/checklists")
+public class DailyChecklistController {
+
+  private final DailyChecklistService dailyChecklistService;
+
+  // TODO: userId는 추후 Spring Security의 @AuthenticationPrincipal 등으로 대체 예정
+
+  @PostMapping("/{checklistId}/complete")
+  public ResponseEntity<DailyChecklistResponse> completeChecklist(
+      @PathVariable Long checklistId,
+      @RequestParam Long userId) {
+    DailyChecklistResponse response = dailyChecklistService.completeChecklist(checklistId, userId);
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/{checklistId}/uncomplete")
+  public ResponseEntity<DailyChecklistResponse> uncompleteChecklist(
+      @PathVariable Long checklistId,
+      @RequestParam Long userId) {
+    DailyChecklistResponse response = dailyChecklistService.uncompleteChecklist(checklistId, userId);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/CareTemplateConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/CareTemplateConverter.java
@@ -1,0 +1,51 @@
+package com.newleaseonlife.SafeDogBe.domain.care.converter;
+
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.CareTemplateCreateRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.CareTemplateResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplate;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CareTemplateConverter {
+
+  // 1. Entity -> Response DTO 변환
+  public CareTemplateResponse toResponse(CareTemplate careTemplate) {
+    if (careTemplate == null) {
+      return null;
+    }
+
+    return CareTemplateResponse.builder()
+        .id(careTemplate.getId())
+        .petId(careTemplate.getPet().getId())
+        .careType(careTemplate.getCareType())
+        .careTypeDescription(careTemplate.getCareType().getDescription())
+        .title(careTemplate.getTitle())
+        .content(careTemplate.getContent())
+        .repeatCycle(careTemplate.getRepeatCycle())
+        .repeatCycleDescription(careTemplate.getRepeatCycle().getDescription())
+        .isActive(careTemplate.isActive())
+        .build();
+  }
+
+  // 2. Entity List -> Response DTO List 변환 (this 키워드로 내부 인스턴스 메서드 호출)
+  public List<CareTemplateResponse> toResponseList(List<CareTemplate> templates) {
+    return templates.stream()
+        .map(this::toResponse)
+        .collect(Collectors.toList());
+  }
+
+  // 3. Request DTO + 연관 Entity -> Entity 변환
+  public CareTemplate toEntity(CareTemplateCreateRequest request, Pet pet) {
+    return CareTemplate.builder()
+        .pet(pet)
+        .careType(request.getCareType())
+        .title(request.getTitle())
+        .content(request.getContent())
+        .repeatCycle(request.getRepeatCycle())
+        // isActive는 Entity의 기본값(true) 또는 빌더 내에서 처리됨
+        .build();
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/ChecklistHistoryLogConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/ChecklistHistoryLogConverter.java
@@ -1,0 +1,41 @@
+package com.newleaseonlife.SafeDogBe.domain.care.converter;
+
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.ChecklistHistoryLogResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.ChecklistHistoryLog;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChecklistHistoryLogConverter {
+
+  // 1. Entity -> Response DTO 변환
+  public ChecklistHistoryLogResponse toResponse(ChecklistHistoryLog log) {
+    return Optional.ofNullable(log)
+        .map(l -> ChecklistHistoryLogResponse.builder()
+            .logId(l.getId())
+            .dailyChecklistId(l.getDailyChecklist().getId())
+            .actionType(l.getActionType())
+            .actionTypeDescription(l.getActionType().getDescription())
+            // 연관된 User 정보 매핑
+            .userId(l.getUser().getId())
+            .userNickname(l.getUser().getNickname())
+            .userProfileImageUrl(l.getUser().getProfileImageUrl())
+            .createdAt(l.getCreatedAt())
+            .build())
+        .orElse(null);
+  }
+
+  // 2. Entity List -> Response DTO List 변환 (타임라인 조회 API용)
+  public List<ChecklistHistoryLogResponse> toResponseList(List<ChecklistHistoryLog> logs) {
+    if (logs == null || logs.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return logs.stream()
+        .map(this::toResponse)
+        .toList();
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/DailyChecklistConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/DailyChecklistConverter.java
@@ -1,0 +1,62 @@
+package com.newleaseonlife.SafeDogBe.domain.care.converter;
+
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.DailyChecklistCreateRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.DailyChecklistResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyChecklist;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DailyChecklistConverter {
+
+  // 1. Entity -> Response DTO 변환
+  public DailyChecklistResponse toResponse(DailyChecklist checklist) {
+    return Optional.ofNullable(checklist)
+        .map(cl -> DailyChecklistResponse.builder()
+            .id(cl.getId())
+            .petId(cl.getPet().getId())
+            // 템플릿이 없는 1회성 체크리스트 방어 로직
+            .careTemplateId(cl.getCareTemplate() != null ? cl.getCareTemplate().getId() : null)
+            .targetDate(cl.getTargetDate())
+            .careType(cl.getCareType())
+            .careTypeDescription(cl.getCareType().getDescription())
+            .title(cl.getTitle())
+            .content(cl.getContent())
+            .isCompleted(cl.isCompleted())
+            // 완료자가 아직 없는 경우를 방어하는 Null-Safe 로직
+            .completedByUserId(cl.getCompletedBy() != null ? cl.getCompletedBy().getId() : null)
+            .completedByNickname(cl.getCompletedBy() != null ? cl.getCompletedBy().getNickname() : null)
+            .version(cl.getVersion())
+            .build())
+        .orElse(null);
+  }
+
+  // 2. Entity List -> Response DTO List 변환
+  public List<DailyChecklistResponse> toResponseList(List<DailyChecklist> checklists) {
+    if (checklists == null || checklists.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return checklists.stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  // 3. Request DTO + 연관 Entity -> Entity 변환 (수동 1회성 할 일 생성용)
+  // 템플릿 없이 수동으로 추가하는 경우이므로 careTemplate 파라미터는 생략합니다.
+  public DailyChecklist toEntity(DailyChecklistCreateRequest request, Pet targetPet) {
+    return DailyChecklist.builder()
+        .pet(targetPet)
+        .targetDate(request.getTargetDate())
+        .careType(request.getCareType())
+        .title(request.getTitle())
+        .content(request.getContent())
+        // careTemplate = null (빌더 기본 동작)
+        // isCompleted = false (엔티티 기본 동작)
+        .build();
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/CareTemplateCreateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/CareTemplateCreateRequest.java
@@ -1,0 +1,31 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.request;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CareTemplateCreateRequest {
+
+  @NotNull(message = "반려동물 ID는 필수입니다.")
+  private Long petId;
+
+  @NotNull(message = "케어 타입은 필수입니다.")
+  private CareType careType;
+
+  @NotBlank(message = "제목은 필수입니다.")
+  private String title;
+
+  private String content; // 선택 사항이므로 validation 생략
+
+  @NotNull(message = "반복 주기는 필수입니다.")
+  private RepeatCycle repeatCycle;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/CareTemplateUpdateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/CareTemplateUpdateRequest.java
@@ -1,0 +1,29 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.request;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CareTemplateUpdateRequest {
+  // 수정 시에는 펫 ID가 변경될 일이 없으므로 제외합니다.
+
+  @NotNull(message = "케어 타입은 필수입니다.")
+  private CareType careType;
+
+  @NotBlank(message = "제목은 필수입니다.")
+  private String title;
+
+  private String content;
+
+  @NotNull(message = "반복 주기는 필수입니다.")
+  private RepeatCycle repeatCycle;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/DailyChecklistCreateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/DailyChecklistCreateRequest.java
@@ -1,0 +1,32 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.request;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DailyChecklistCreateRequest {
+
+  @NotNull(message = "반려동물 ID는 필수입니다.")
+  private Long petId;
+
+  @NotNull(message = "목표 날짜는 필수입니다.")
+  private LocalDate targetDate;
+
+  @NotNull(message = "케어 타입은 필수입니다.")
+  private CareType careType;
+
+  @NotBlank(message = "제목은 필수입니다.")
+  private String title;
+
+  private String content;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/DailyChecklistUpdateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/DailyChecklistUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DailyChecklistUpdateRequest {
+
+  @NotBlank(message = "제목은 필수입니다.")
+  private String title;
+
+  private String content;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/CareTemplateResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/CareTemplateResponse.java
@@ -1,0 +1,30 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.response;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CareTemplateResponse {
+
+  private Long id;
+  private Long petId;
+
+  // Enum의 원본 값(서버용)과 프론트엔드 노출용 한글 값을 동시에 내려줍니다.
+  private CareType careType;
+  private String careTypeDescription;
+
+  private String title;
+  private String content;
+
+  private RepeatCycle repeatCycle;
+  private String repeatCycleDescription;
+
+  private boolean isActive;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/ChecklistHistoryLogResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/ChecklistHistoryLogResponse.java
@@ -1,0 +1,34 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.response;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.ChecklistActionType;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.ChecklistActionType;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChecklistHistoryLogResponse {
+
+  private Long logId;
+
+  // 어떤 체크리스트에 대한 로그인지
+  private Long dailyChecklistId;
+
+  // 행위 종류 (CHECK, UNCHECK 등)
+  private ChecklistActionType actionType;
+  private String actionTypeDescription;
+
+  // 행위를 한 사람 (공동 보호자 중 누구인지 식별)
+  private Long userId;
+  private String userNickname;
+  private String userProfileImageUrl;
+
+  // 언제 했는지 (앱에서 "오전 8시 5분 완료" 등으로 표시)
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/DailyChecklistResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/DailyChecklistResponse.java
@@ -1,0 +1,39 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.response;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DailyChecklistResponse {
+
+  private Long id;
+  private Long petId;
+
+  // 원본 템플릿 정보 (수동으로 생성한 체크리스트면 null일 수 있음)
+  private Long careTemplateId;
+
+  private LocalDate targetDate;
+
+  private CareType careType;
+  private String careTypeDescription;
+
+  private String title;
+  private String content;
+
+  private boolean isCompleted;
+
+  // 누가 완료했는지 (아직 완료 안 됐으면 null)
+  private Long completedByUserId;
+  private String completedByNickname;
+
+  // 클라이언트에서 완료 API 호출 시 함께 넘겨야 할 낙관적 락 버전
+  private Integer version;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/CareTemplate.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/CareTemplate.java
@@ -1,0 +1,99 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "care_template",
+    indexes = {
+        // 반려동물별 템플릿 목록 조회가 매우 빈번하므로 인덱스 필수
+        @Index(name = "idx_care_template_pet_id", columnList = "pet_id")
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class CareTemplate {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  // 반려동물 삭제 시 템플릿도 연쇄 삭제(Cascade)되도록 DB 레벨 제약조건 적용
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "pet_id", nullable = false, foreignKey = @ForeignKey(name = "fk_care_template_pet"))
+  private Pet pet;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 50)
+  private CareType careType;
+
+  @Column(nullable = false, length = 200)
+  private String title;
+
+  @Column(columnDefinition = "TEXT")
+  private String content;
+
+  @Enumerated(EnumType.STRING)
+  @Column(length = 50)
+  private RepeatCycle repeatCycle;
+
+  // 논리적 삭제 및 스케줄러 생성 여부를 판단하는 핵심 플래그
+  @Column(nullable = false)
+  private boolean isActive = true;
+
+  // SQL 스키마에 updated_at이 없으므로 생성 시간만 자동 추적
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Builder
+  public CareTemplate(Pet pet, CareType careType, String title, String content, RepeatCycle repeatCycle) {
+    this.pet = pet;
+    this.careType = careType;
+    this.title = title;
+    this.content = content;
+    this.repeatCycle = repeatCycle;
+    this.isActive = true;
+  }
+
+  // 비즈니스 로직 1: 템플릿 내용 수정 (제목, 내용, 반복 주기)
+  public void updateTemplate(CareType careType, String title, String content, RepeatCycle repeatCycle) {
+    if (careType != null) this.careType = careType;
+    if (title != null) this.title = title;
+    if (content != null) this.content = content;
+    if (repeatCycle != null) this.repeatCycle = repeatCycle;
+  }
+
+  // 비즈니스 로직 2: 템플릿 비활성화 (Soft Delete 방식)
+  // 과거의 완료된 체크리스트 기록을 유지하기 위해 물리적 삭제(DELETE) 대신 비활성화 처리
+  public void deactivate() {
+    this.isActive = false;
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/ChecklistHistoryLog.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/ChecklistHistoryLog.java
@@ -1,0 +1,74 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.ChecklistActionType;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "checklist_history_log",
+    indexes = {
+        // 특정 체크리스트의 이력을 빠르게 조회하기 위한 인덱스
+        @Index(name = "idx_checklist_log_checklist_id", columnList = "daily_checklist_id"),
+        // 특정 유저의 활동 이력을 조회하기 위한 인덱스 (옵션)
+        @Index(name = "idx_checklist_log_user_id", columnList = "user_id")
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class ChecklistHistoryLog {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  // 부모인 데일리 체크리스트가 지워지면 로그도 함께 날아가도록 CASCADE 설정 (DB 단에서 처리)
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "daily_checklist_id", nullable = false, foreignKey = @ForeignKey(name = "fk_log_checklist"))
+  private DailyChecklist dailyChecklist;
+
+  // 누가 행위를 했는지 유저 정보 연결
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_log_user"))
+  private User user;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 50)
+  private ChecklistActionType actionType;
+
+  // 로그는 수정되지 않으므로 @LastModifiedDate 없음
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Builder
+  public ChecklistHistoryLog(DailyChecklist dailyChecklist, User user, ChecklistActionType actionType) {
+    this.dailyChecklist = dailyChecklist;
+    this.user = user;
+    this.actionType = actionType;
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/DailyChecklist.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/DailyChecklist.java
@@ -1,0 +1,127 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "daily_checklist",
+    indexes = {
+        // 백엔드 핵심: 앱의 메인 화면인 "특정 날짜의 반려동물 할 일 목록" 조회 최적화용 복합 인덱스
+        @Index(name = "idx_daily_checklist_pet_date", columnList = "pet_id, target_date"),
+        // 특정 사용자가 완료한 목록을 찾을 때 풀스캔 방지
+        @Index(name = "idx_daily_checklist_completed_by", columnList = "completed_by")
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class DailyChecklist {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  // 반려동물 삭제 시 할 일 목록도 같이 삭제(CASCADE)
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "pet_id", nullable = false, foreignKey = @ForeignKey(name = "fk_daily_checklist_pet"))
+  private Pet pet;
+
+  // 원본 템플릿이 삭제되더라도 기록은 남아야 하므로 제약조건을 SET NULL로 설계
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "care_template_id", foreignKey = @ForeignKey(name = "fk_daily_checklist_template"))
+  private CareTemplate careTemplate;
+
+  @Column(nullable = false)
+  private LocalDate targetDate;
+
+  // --- 스냅샷(Snapshot) 데이터: 원본 템플릿에서 복사해옴 ---
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 50)
+  private CareType careType;
+
+  @Column(nullable = false, length = 200)
+  private String title;
+
+  @Column(columnDefinition = "TEXT")
+  private String content;
+  // ---------------------------------------------------
+
+  @Column(nullable = false)
+  private boolean isCompleted = false;
+
+  // 누가 이 항목을 완료 처리했는지 추적 (마찬가지로 유저 탈퇴 시 SET NULL 처리)
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "completed_by", foreignKey = @ForeignKey(name = "fk_daily_checklist_completed"))
+  private User completedBy;
+
+  // 백엔드 핵심: 동시성 제어를 위한 낙관적 락(Optimistic Lock)
+  @Version
+  @Column(nullable = false)
+  private Integer version;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+  @Builder
+  public DailyChecklist(Pet pet, CareTemplate careTemplate, LocalDate targetDate,
+      CareType careType, String title, String content) {
+    this.pet = pet;
+    this.careTemplate = careTemplate;
+    this.targetDate = targetDate;
+    this.careType = careType;
+    this.title = title;
+    this.content = content;
+    this.isCompleted = false;
+  }
+
+  // 비즈니스 로직 1: 체크리스트 완료 처리 (어떤 유저가 완료했는지 파라미터로 받음)
+  public void complete(User user) {
+    this.isCompleted = true;
+    this.completedBy = user;
+  }
+
+  // 비즈니스 로직 2: 체크리스트 완료 취소
+  public void uncomplete() {
+    this.isCompleted = false;
+    this.completedBy = null;
+  }
+
+  // 비즈니스 로직 3: 스냅샷 내용 수정 (오늘만 특별히 내용을 바꿀 때)
+  public void updateContent(String newTitle, String newContent) {
+    if (newTitle != null) this.title = newTitle;
+    if (newContent != null) this.content = newContent;
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/CareType.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/CareType.java
@@ -1,0 +1,17 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CareType {
+  MEAL("식사"),
+  WALK("산책"),
+  MEDICINE("약 복용"),
+  BATH("목욕"),
+  HOSPITAL("병원 방문"),
+  ETC("기타");
+
+  private final String description;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/ChecklistActionType.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/ChecklistActionType.java
@@ -1,0 +1,14 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChecklistActionType {
+  CHECK("완료 처리"),
+  UNCHECK("완료 취소"),
+  UPDATE_MEMO("메모/내용 수정");
+
+  private final String description;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/RepeatCycle.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/RepeatCycle.java
@@ -1,0 +1,15 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RepeatCycle {
+  NONE("반복 없음"),
+  DAILY("매일"),
+  WEEKLY("매주"),
+  MONTHLY("매월");
+
+  private final String description;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/CareTemplateRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/CareTemplateRepository.java
@@ -1,0 +1,20 @@
+package com.newleaseonlife.SafeDogBe.domain.care.repository;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplate;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CareTemplateRepository extends JpaRepository<CareTemplate, Long> {
+
+  // 1. 특정 반려동물의 "현재 활성화된" 케어 템플릿 목록 조회 (앱 화면 노출용)
+  List<CareTemplate> findByPetIdAndIsActiveTrue(Long petId);
+
+  // 2. 매일 자정 스케줄러(Batch) 실행 시, 전체 반려동물의 활성화된 반복 템플릿을 가져오기 위한 쿼리
+  // N+1 방지를 위해 페치 조인 사용
+  @Query("SELECT ct FROM CareTemplate ct JOIN FETCH ct.pet WHERE ct.isActive = true AND ct.repeatCycle = :repeatCycle")
+  List<CareTemplate> findAllActiveTemplatesByCycleWithPet(@Param("repeatCycle") RepeatCycle repeatCycle);
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/ChecklistHistoryLogRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/ChecklistHistoryLogRepository.java
@@ -1,0 +1,24 @@
+package com.newleaseonlife.SafeDogBe.domain.care.repository;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.ChecklistHistoryLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ChecklistHistoryLogRepository extends JpaRepository<ChecklistHistoryLog, Long> {
+
+  // 1. 특정 체크리스트 항목의 변경 이력 조회 (최신순 정렬)
+  // N+1 방지를 위해 액션을 수행한 유저 정보도 함께 Fetch Join
+  @Query("SELECT l FROM ChecklistHistoryLog l JOIN FETCH l.user WHERE l.dailyChecklist.id = :checklistId ORDER BY l.createdAt DESC")
+  List<ChecklistHistoryLog> findByDailyChecklistIdWithUser(@Param("checklistId") Long checklistId);
+
+  // 2. 백엔드 핵심: 90일이 지난 오래된 로그 대량 삭제 (Batch 스케줄러용)
+  // @Modifying을 사용하여 영속성 컨텍스트를 우회하고 DB에 직접 DELETE 쿼리를 날려 성능 최적화
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM ChecklistHistoryLog l WHERE l.createdAt < :cutoffDate")
+  int deleteOldLogs(@Param("cutoffDate") LocalDateTime cutoffDate);
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/DailyChecklistRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/DailyChecklistRepository.java
@@ -1,0 +1,19 @@
+package com.newleaseonlife.SafeDogBe.domain.care.repository;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyChecklist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface DailyChecklistRepository extends JpaRepository<DailyChecklist, Long> {
+
+  // 1. 메인 화면: 특정 반려동물의 '오늘(특정 날짜)' 할 일 목록 조회 (N+1 방지 페치 조인)
+  @Query("SELECT d FROM DailyChecklist d LEFT JOIN FETCH d.completedBy WHERE d.pet.id = :petId AND d.targetDate = :targetDate")
+  List<DailyChecklist> findAllByPetIdAndTargetDateWithUser(@Param("petId") Long petId, @Param("targetDate") LocalDate targetDate);
+
+  // 2. 스케줄러 방어 로직: 이미 오늘 날짜로 해당 템플릿 기반의 체크리스트가 생성되었는지 확인
+  boolean existsByCareTemplateIdAndTargetDate(Long careTemplateId, LocalDate targetDate);
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/CareSchedulerService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/CareSchedulerService.java
@@ -1,0 +1,72 @@
+package com.newleaseonlife.SafeDogBe.domain.care.service;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplate;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyChecklist;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
+import com.newleaseonlife.SafeDogBe.domain.care.repository.CareTemplateRepository;
+import com.newleaseonlife.SafeDogBe.domain.care.repository.DailyChecklistRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j // 콘솔에 배치 결과를 찍기 위한 로깅 어노테이션
+@Service
+@RequiredArgsConstructor
+public class CareSchedulerService {
+
+  private final CareTemplateRepository careTemplateRepository;
+  private final DailyChecklistRepository dailyChecklistRepository;
+
+  /**
+   * 매일 자정(KST 00:00:00)에 실행되는 자동 체크리스트 생성 배치
+   * cron = "초 분 시 일 월 요일"
+   */
+  @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+  @Transactional
+  public void generateDailyChecklists() {
+    // 1. 기획서 기준대로 시스템 시간이 아닌 철저히 KST(한국 시간) 기준의 오늘 날짜 획득
+    LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+    log.info("[Batch Start] {} 일자 반려노트 DailyChecklist 자동 생성 시작", today);
+
+    // 2. '매일(DAILY)' 반복 설정이 되어 있으면서 비활성화되지 않은(isActive=true) 템플릿 목록 싹쓸이 (N+1 방지 적용)
+    List<CareTemplate> dailyTemplates = careTemplateRepository.findAllActiveTemplatesByCycleWithPet(RepeatCycle.DAILY);
+
+    // 저장을 위해 모아둘 리스트 (건바이건 Insert 방지)
+    List<DailyChecklist> checklistsToSave = new ArrayList<>();
+
+    for (CareTemplate template : dailyTemplates) {
+      // 3. 방어 로직: 스케줄러가 모종의 이유로 두 번 돌더라도, 오늘 날짜로 이미 생성된 할 일이 있다면 건너뜀 (중복 생성 방지)
+      boolean isAlreadyGenerated = dailyChecklistRepository.existsByCareTemplateIdAndTargetDate(template.getId(), today);
+
+      if (!isAlreadyGenerated) {
+        // 4. 원본 템플릿의 '현재' 텍스트를 그대로 복사(스냅샷)하여 새로운 엔티티 조립
+        DailyChecklist newChecklist = DailyChecklist.builder()
+            .pet(template.getPet())
+            .careTemplate(template)
+            .targetDate(today)
+            .careType(template.getCareType())
+            .title(template.getTitle())
+            .content(template.getContent())
+            .build();
+
+        checklistsToSave.add(newChecklist);
+      }
+    }
+
+    // 5. 모아둔 리스트를 한 번의 쿼리(Batch Insert)로 DB에 꽂아 넣음 (성능 최적화)
+    if (!checklistsToSave.isEmpty()) {
+      dailyChecklistRepository.saveAll(checklistsToSave);
+      log.info("[Batch Success] 총 {}개의 DailyChecklist가 성공적으로 자동 생성되었습니다.", checklistsToSave.size());
+    } else {
+      log.info("[Batch End] 오늘 날짜로 새로 생성할 DailyChecklist가 없습니다.");
+    }
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/CareTemplateService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/CareTemplateService.java
@@ -1,0 +1,49 @@
+package com.newleaseonlife.SafeDogBe.domain.care.service;
+
+import com.newleaseonlife.SafeDogBe.domain.care.converter.CareTemplateConverter;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.CareTemplateCreateRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.CareTemplateResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplate;
+import com.newleaseonlife.SafeDogBe.domain.care.repository.CareTemplateRepository;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CareTemplateService {
+
+  private final CareTemplateRepository careTemplateRepository;
+  private final PetRepository petRepository;
+  private final CareTemplateConverter careTemplateConverter;
+
+  @Transactional
+  public CareTemplateResponse createTemplate(CareTemplateCreateRequest request) {
+    // 1. 반려동물 검증 및 조회
+    Pet pet = petRepository.findById(request.getPetId())
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 반려동물입니다."));
+
+    // 2. Converter를 통해 Entity 조립
+    CareTemplate careTemplate = careTemplateConverter.toEntity(request, pet);
+
+    // 3. 영속화
+    CareTemplate savedTemplate = careTemplateRepository.save(careTemplate);
+
+    // 4. Response DTO로 변환하여 반환
+    return careTemplateConverter.toResponse(savedTemplate);
+  }
+
+  @Transactional
+  public void deactivateTemplate(Long templateId) {
+    // 1. 템플릿 조회
+    CareTemplate template = careTemplateRepository.findById(templateId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 템플릿입니다."));
+
+    // 2. 비활성화 (Soft Delete) - 더티 체킹에 의해 자동 UPDATE 쿼리 발생
+    template.deactivate();
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/DailyChecklistService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/DailyChecklistService.java
@@ -1,0 +1,79 @@
+package com.newleaseonlife.SafeDogBe.domain.care.service;
+
+import com.newleaseonlife.SafeDogBe.domain.care.converter.DailyChecklistConverter;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.DailyChecklistResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.ChecklistHistoryLog;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyChecklist;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.ChecklistActionType;
+import com.newleaseonlife.SafeDogBe.domain.care.repository.ChecklistHistoryLogRepository;
+import com.newleaseonlife.SafeDogBe.domain.care.repository.DailyChecklistRepository;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DailyChecklistService {
+
+  private final DailyChecklistRepository dailyChecklistRepository;
+  private final ChecklistHistoryLogRepository historyLogRepository;
+  private final UserRepository userRepository;
+  private final DailyChecklistConverter checklistConverter;
+
+  @Transactional
+  public DailyChecklistResponse completeChecklist(Long checklistId, Long userId) {
+    // 1. 체크리스트와 유저 조회
+    DailyChecklist checklist = dailyChecklistRepository.findById(checklistId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 할 일입니다."));
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+    // 2. 이미 완료된 항목인지 1차 방어 로직 (JPA 낙관적 락이 2차 방어 수행)
+    if (checklist.isCompleted()) {
+      throw new IllegalStateException("이미 완료 처리된 항목입니다.");
+    }
+
+    // 3. 도메인 로직 호출: 완료 상태 및 행위자 업데이트 (더티 체킹 발생)
+    checklist.complete(user);
+
+    // 4. 부수 효과(Side Effect): 히스토리 로그 생성 및 저장
+    ChecklistHistoryLog log = ChecklistHistoryLog.builder()
+        .dailyChecklist(checklist)
+        .user(user)
+        .actionType(ChecklistActionType.CHECK)
+        .build();
+    historyLogRepository.save(log);
+
+    // 5. 프론트엔드로 최신 상태(Version 포함) 반환
+    return checklistConverter.toResponse(checklist);
+  }
+
+  @Transactional
+  public DailyChecklistResponse uncompleteChecklist(Long checklistId, Long userId) {
+    DailyChecklist checklist = dailyChecklistRepository.findById(checklistId)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 할 일입니다."));
+    User user = userRepository.findById(userId) // 취소를 누른 사람의 정보
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
+    if (!checklist.isCompleted()) {
+      throw new IllegalStateException("아직 완료되지 않은 항목입니다.");
+    }
+
+    // 도메인 로직: 상태 초기화
+    checklist.uncomplete();
+
+    // 부수 효과: "취소" 로그 기록 (누가 취소했는지 추적)
+    ChecklistHistoryLog log = ChecklistHistoryLog.builder()
+        .dailyChecklist(checklist)
+        .user(user)
+        .actionType(ChecklistActionType.UNCHECK)
+        .build();
+    historyLogRepository.save(log);
+
+    return checklistConverter.toResponse(checklist);
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/enums/GuardianRole.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/enums/GuardianRole.java
@@ -1,0 +1,13 @@
+package com.newleaseonlife.SafeDogBe.domain.pet.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum GuardianRole {
+  OWNER("메인 보호자"),
+  CAREGIVER("공동 보호자");
+
+  private final String description;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/config/S3Config.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/config/S3Config.java
@@ -1,0 +1,37 @@
+package com.newleaseonlife.SafeDogBe.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+  @Value("${cloud.aws.credentials.access-key}")
+  private String accessKey;
+
+  @Value("${cloud.aws.credentials.secret-key}")
+  private String secretKey;
+
+  @Value("${cloud.aws.region.static}")
+  private String region;
+
+  @Bean
+  public AmazonS3 amazonS3Client() {
+    // 1. AWS 자격 증명(Credentials) 객체 생성
+    AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+    // 2. S3 클라이언트 빌더를 통해 Region과 자격 증명을 엮어서 AmazonS3 객체 반환
+    return AmazonS3ClientBuilder
+        .standard()
+        .withCredentials(new AWSStaticCredentialsProvider(credentials))
+        .withRegion(region)
+        .build();
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/config/SwaggerConfig.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/config/SwaggerConfig.java
@@ -1,0 +1,27 @@
+package com.newleaseonlife.SafeDogBe.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+  @Bean
+  public OpenAPI openAPI() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("SafeDog (개과천선) API 명세서")
+            .description("반려동물 공동 양육 및 케어 노트를 위한 API")
+            .version("v1.0.0"))
+        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+        .components(new Components()
+            .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")));
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/infra/aws/s3/S3ServiceImpl.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/infra/aws/s3/S3ServiceImpl.java
@@ -1,0 +1,99 @@
+package com.newleaseonlife.SafeDogBe.infra.aws.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3ServiceImpl implements S3ServicePort {
+
+  private final AmazonS3 amazonS3;
+
+  @Value("${cloud.aws.s3.bucket}")
+  private String bucket;
+
+  // 기획서 요구사항: 10MB 제한, 특정 확장자 허용
+  private static final long MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+  private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "heic");
+
+  @Override
+  public String uploadImage(String directory, MultipartFile multipartFile) {
+    validateFile(multipartFile);
+
+    String originalFilename = multipartFile.getOriginalFilename();
+    String extension = getFileExtension(originalFilename);
+    String s3FileName = directory + "/" + UUID.randomUUID() + "." + extension;
+
+    ObjectMetadata metadata = new ObjectMetadata();
+    metadata.setContentType(multipartFile.getContentType());
+    metadata.setContentLength(multipartFile.getSize());
+
+    try (InputStream inputStream = multipartFile.getInputStream()) {
+      amazonS3.putObject(new PutObjectRequest(bucket, s3FileName, inputStream, metadata)
+          // (선택 사항) 버킷 정책에 따라 Public Read 권한 부여
+          .withCannedAcl(CannedAccessControlList.PublicRead));
+    } catch (IOException e) {
+      log.error("S3 파일 업로드 중 오류 발생: {}", e.getMessage());
+      throw new RuntimeException("이미지 업로드에 실패했습니다.", e);
+    }
+
+    return amazonS3.getUrl(bucket, s3FileName).toString();
+  }
+
+  @Override
+  public void deleteImage(String fileUrl) {
+    if (fileUrl == null || !fileUrl.contains(bucket)) {
+      return;
+    }
+    try {
+      // URL에서 S3 Key(폴더명/파일명)만 추출
+      String s3Key = fileUrl.substring(fileUrl.indexOf(bucket) + bucket.length() + 1);
+      amazonS3.deleteObject(new DeleteObjectRequest(bucket, s3Key));
+      log.info("S3 파일 삭제 완료: {}", s3Key);
+    } catch (Exception e) {
+      log.error("S3 파일 삭제 중 오류 발생: {}", e.getMessage());
+    }
+  }
+
+  private void validateFile(MultipartFile file) {
+    if (file == null || file.isEmpty()) {
+      throw new IllegalArgumentException("파일이 비어있습니다.");
+    }
+    if (file.getSize() > MAX_FILE_SIZE) {
+      throw new IllegalArgumentException("이미지는 10MB 이하만 등록 가능합니다.");
+    }
+
+    String originalFilename = file.getOriginalFilename();
+    if (originalFilename == null || originalFilename.isEmpty()) {
+      throw new IllegalArgumentException("파일명이 없습니다.");
+    }
+
+    String extension = getFileExtension(originalFilename).toLowerCase();
+    if (!ALLOWED_EXTENSIONS.contains(extension)) {
+      throw new IllegalArgumentException("이미지는 jpg, jpeg, png, HEIC 만 등록이 가능합니다.");
+    }
+  }
+
+  private String getFileExtension(String filename) {
+    int lastDotIndex = filename.lastIndexOf('.');
+    if (lastDotIndex == -1 || lastDotIndex == filename.length() - 1) {
+      return "";
+    }
+    return filename.substring(lastDotIndex + 1);
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/infra/aws/s3/S3ServicePort.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/infra/aws/s3/S3ServicePort.java
@@ -1,0 +1,20 @@
+package com.newleaseonlife.SafeDogBe.infra.aws.s3;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3ServicePort {
+
+  /**
+   * S3에 이미지 업로드 후 접근 가능한 객체 URL 반환
+   * @param directory S3 내부 폴더명 (예: "profiles", "care-notes")
+   * @param multipartFile 업로드할 파일
+   * @return 업로드된 파일의 S3 URL
+   */
+  String uploadImage(String directory, MultipartFile multipartFile);
+
+  /**
+   * S3에서 파일 삭제
+   * @param fileUrl 삭제할 파일의 S3 URL
+   */
+  void deleteImage(String fileUrl);
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -102,3 +102,13 @@ server:
       charset: UTF-8
       enabled: true
       force: true
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_S3_Access Key}
+      secret-key: ${AWS_S3_Secret Key}
+    region:
+      static: ap-northeast-2 # 서울 리전
+    s3:
+      bucket: safedog-bucket # S3 버킷 이름


### PR DESCRIPTION
## 🔗 관련 이슈

> Close #33, #35, #36, #41

## 📌 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

* **Care 도메인 (반려노트 핵심 비즈니스)**
* `CareTemplate`, `DailyChecklist`, `ChecklistHistoryLog` 엔티티 및 Repository 구현
* Request / Response DTO 패키지 분리 및 Converter 클래스(`@Component`) 구현
* 체크리스트 상태 변경(완료/취소) 로직 및 연관 히스토리 로그 적재 비즈니스 로직 구현
* KST 자정(00:00) 기준 일일 체크리스트 자동 생성 Batch 스케줄러 로직 구현


* **AWS S3 인프라 도메인**
* AWS SDK 연동을 위한 `S3Config` 환경 세팅
* 도메인과 인프라 분리를 위한 Port-Adapter 패턴 적용 (`S3ServicePort`, `S3ServiceImpl`)
* 10MB 용량, 지정 확장자(HEIC 포함) 검증 로직 및 S3 업로드 공용 API (`ImageController`) 구현



## 🛠️ 주요 변경 사항 및 리팩토링

> 핵심 백엔드 설계 및 기술적 의사결정 사항입니다.

* **낙관적 락(Optimistic Lock) 적용 (`@Version`)**
* 다중 보호자가 동시에 동일한 `DailyChecklist`를 체크할 때 발생하는 갱신 손실(Lost Update) 방지. 동시 접근 시 후행 트랜잭션은 예외를 던져 데이터 정합성 보장.


* **Soft Delete & Snapshot 패턴 적용**
* `CareTemplate` 삭제 시 과거 체크리스트 데이터 고아화 방지를 위해 `isActive` 플래그를 통한 논리적 삭제 적용.
* 스케줄러 자동 생성 시 템플릿의 데이터를 복사(Snapshot)하여 과거 할 일 기록의 불변성 유지.


* **Bulk Delete 연산 최적화 (`@Modifying`)**
* 90일이 경과한 `ChecklistHistoryLog` 삭제 시, N+1 조회를 방지하고 성능을 최적화하기 위해 단일 벌크 삭제 쿼리 적용.


* **N+1 문제 사전 차단 (`JOIN FETCH`)**
* 스케줄러 조회 및 리스트 반환 쿼리 등에 페치 조인을 선제적으로 적용하여 DB I/O 최적화.


* **Converter 객체지향적 리팩토링**
* `static` 메서드 사용을 지양하는 팀 컨벤션에 맞추어 Converter를 스프링 빈(`@Component`)으로 등록하고 의존성 주입 방식으로 전환.


## ✅ 체크리스트

* [ ] 브랜치 전략(소문자)을 준수했나요?
* [ ] 커밋 메시지 규칙을 지켰나요?
* [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
* [ ] 최소 1명의 리뷰어 승인을 확인했나요?

## 💡 참고 사항

> 로컬 테스트 및 리뷰 시 참고 부탁드립니다.

* **[중요] AWS S3 세팅:** S3 연동을 위해 `application.yml`에 AWS 자격 증명(`access-key`, `secret-key`) 및 버킷 정보 추가가 필요합니다. **(절대 GitHub에 Key가 노출되지 않도록 주의해주세요!)**
* **Batch 스케줄러 활성화:** 매일 자정에 도는 배치를 위해 최상단 `Application` 클래스에 `@EnableScheduling` 어노테이션을 추가했습니다.
* 프론트엔드는 회원가입이나 반려동물 등록 전, 먼저 `/api/images` 공용 API를 호출해 S3 URL을 반환받은 뒤 해당 URL을 도메인 DTO에 담아 요청하면 됩니다.