### PR TITLE
feat: AWS S3 이미지 업로드 인프라 구축 및 공용 API 구현

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/common/dto/response/ImageUploadResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/common/dto/response/ImageUploadResponse.java
@@ -1,0 +1,14 @@
+package com.newleaseonlife.SafeDogBe.global.common.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ImageUploadResponse {
+  private String imageUrl;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/config/S3Config.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/config/S3Config.java
@@ -1,8 +1,6 @@
 package com.newleaseonlife.SafeDogBe.global.config;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
@@ -13,24 +11,15 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class S3Config {
 
-  @Value("${cloud.aws.credentials.access-key}")
-  private String accessKey;
-
-  @Value("${cloud.aws.credentials.secret-key}")
-  private String secretKey;
-
   @Value("${cloud.aws.region.static}")
   private String region;
 
   @Bean
   public AmazonS3 amazonS3Client() {
-    // 1. AWS 자격 증명(Credentials) 객체 생성
-    AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
-
-    // 2. S3 클라이언트 빌더를 통해 Region과 자격 증명을 엮어서 AmazonS3 객체 반환
+    // 백엔드 보안 핵심: AWS 자격 증명 탐색 체인 적용 (OIDC, EC2 IAM Role 자동 인식)
     return AmazonS3ClientBuilder
         .standard()
-        .withCredentials(new AWSStaticCredentialsProvider(credentials))
+        .withCredentials(DefaultAWSCredentialsProviderChain.getInstance())
         .withRegion(region)
         .build();
   }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/infra/aws/s3/ImageController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/infra/aws/s3/ImageController.java
@@ -1,0 +1,38 @@
+package com.newleaseonlife.SafeDogBe.infra.aws.s3;
+
+import com.newleaseonlife.SafeDogBe.global.common.dto.response.ImageUploadResponse;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+  private final S3ServicePort s3ServicePort;
+
+  /**
+   * 공용 이미지 업로드 API
+   * 프론트엔드는 이 API를 호출해 URL을 반환받은 뒤, 도메인 생성 API(유저, 반려동물 등)에 해당 URL을 문자열로 넘깁니다.
+   * * @param directory S3 내 폴더명 (예: profiles, pets, care-notes)
+   * @param file 업로드할 이미지 파일
+   */
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public ResponseEntity<ImageUploadResponse> uploadImage(
+      @RequestParam(value = "directory", defaultValue = "general") String directory,
+      @RequestPart("file") MultipartFile file) {
+
+    String uploadedUrl = s3ServicePort.uploadImage(directory, file);
+
+    ImageUploadResponse response = ImageUploadResponse.builder()
+        .imageUrl(uploadedUrl)
+        .build();
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -3,9 +3,11 @@
 ################################
 
 spring:
-  application:
-    name:
-
+  config:
+    activate:
+      on-profile: prod
+    # 운영 프로필(prod)이 활성화될 때만 AWS SSM에서 파라미터를 가져옴
+    import: "aws-parameterstore:/safedog/prod/"
   # 1. 데이터베이스 설정
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT:3306}/${DB_NAME}?useSSL=false&allowPublicKeyRetrieval=true
@@ -105,9 +107,6 @@ server:
 
 cloud:
   aws:
-    credentials:
-      access-key: ${AWS_S3_Access Key}
-      secret-key: ${AWS_S3_Secret Key}
     region:
       static: ap-northeast-2 # 서울 리전
     s3:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,15 @@
+# ==========================================
+# 1. 공통 설정 (모든 환경 적용)
+# ==========================================
 spring:
-  profiles:
-    active: local
   application:
     name: SafeDogBe
+  profiles:
+    active: local # 기본 구동 환경을 local로 설정 (운영 서버 구동 시 환경변수로 prod 덮어쓰기)
+
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: safedog-bucket


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호
#45


## 📌 작업 내용
* 반려동물 프로필, 사료/영양제 성분표 등 서비스 전반에서 사용될 AWS S3 이미지 업로드 및 삭제 인프라를 구축했습니다.
* 프론트엔드에서 이미지를 먼저 서버로 전송하고, S3에 저장된 이미지의 URL을 반환받을 수 있는 공용 이미지 업로드 API를 구현했습니다.

## 🛠️ 주요 변경 사항 및 리팩토링
S3 인프라 계층 구현 (Port-Adapter 패턴 적용)

* S3ServicePort 인터페이스와 S3ServiceImpl 구현체를 분리하여 도메인 계층과 인프라 계층의 의존성을 분리했습니다.
* 기획서 요구사항에 맞춘 파일 검증 로직 추가 (최대 10MB, jpg, jpeg, png, heic 확장자만 허용).
* 공용 이미지 컨트롤러 (ImageController) 추가
* POST /api/images 엔드포인트 생성.
* directory 파라미터를 통해 S3 내부 폴더(예: profiles, care-notes 등)를 동적으로 구분하여 저장할 수 있도록 구성했습니다.
* AWS SDK 의존성 및 설정 클래스 (S3Config) 추가
* aws-java-sdk-s3 라이브러리 추가 및 S3 Client 빈 등록.

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
