### PR TITLE
[feat]: cicd 무중단 배포 하기 (#47)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,35 +1,70 @@
 # .github/workflows/deploy.yml
-name: Deploy
+name: Deploy Spring Boot to EC2
 
 on:
   push:
-    branches: [ "main" ]
-    
+    branches: [ "main" ] # main 브랜치 푸시 시 자동 실행
+
 permissions:
-  id-token: write # OIDC 사용을 위해 필수
+  id-token: write # OIDC 인증 필수
   contents: read
 
+env:
+  ECR_REPOSITORY: safe_dog-api
+  # [수정] 위에서 만든 GitHub Actions용 IAM 역할의 ARN 입력
+
 jobs:
-  build-and-push:
+  build-and-deploy:
     runs-on: ubuntu-latest
-    outputs:
-      image_tag: ${{ steps.build-image.outputs.image_tag }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      # 1. AWS 자격 증명 획득 (OIDC 방식)
-      - name: Configure AWS credentials
+      - name: Set up JDK 21 (본인 버전에 맞게 수정)
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.IAM_ARN_GITHUB }} # 만든 Role ARN
+          role-to-assume: ${{ secrets.IAM_ROLE_ARN }}
           aws-region: ap-northeast-2
 
-      # 2. ECR 로그인 (이 작업을 거치면 Jib이 자동으로 인증을 인식함)
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      # 3. Jib 빌드 및 푸시
-      - name: Build and push with Jib
-        run: ./gradlew jib
+      - name: Build and Push Docker Image (Jib 사용)
+        run: |
+          ./gradlew jib \
+            -Djib.to.image=${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }} \
+            -Djib.to.tags=latest
+
+      - name: Trigger EC2 Deploy Script via SSM
+        run: |
+          # [수정] 대상 EC2 인스턴스 ID를 GitHub Secrets에 저장 후 가져오기
+          INSTANCE_ID="${{ secrets.EC2_INSTANCE_ID }}"
+          
+          # EC2 서버 내부의 deploy.sh 스크립트 실행 명령을 SSM으로 전송
+          COMMAND="bash /home/ubuntu/cicd/deploy.sh"
+          
+          echo "Sending deployment command to EC2 via SSM..."
+          COMMAND_ID=$(aws ssm send-command \
+            --document-name "AWS-RunShellScript" \
+            --targets "Key=InstanceIds,Values=$INSTANCE_ID" \
+            --parameters "commands=[$COMMAND]" \
+            --comment "Trigger Deploy Script" \
+            --query "Command.CommandId" \
+            --output text)
+          
+          echo "Command ID: $COMMAND_ID"
+          
+          # 배포 스크립트가 성공적으로 끝날 때까지 대기 (실패 시 CI 파이프라인도 실패 처리)
+          echo "Waiting for command to complete..."
+          aws ssm wait command-executed \
+            --command-id "$COMMAND_ID" \
+            --instance-id "$INSTANCE_ID"
+          
+          echo "Deployment command executed successfully!"

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ jib {
         image = 'eclipse-temurin:21-jre-alpine' // 경량화된 Alpine 리눅스 기반 JRE 21 사용
     }
     to {
-        image = '237245538374.dkr.ecr.ap-northeast-2.amazonaws.com/my-spring-boot-app_2_13' // ECR 주소 또는 DockerHub 주소
+        image = System.getenv('IMAGE_NAME') ?:'safedog' // ECR 주소 또는 DockerHub 주소
         tags = ['latest', "${project.version}".toString()]
     }
     container {

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -32,8 +32,8 @@ spring:
   # 3. Redis 설정
   data:
     redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT}
+      host: redis
+      port: 6379
       password: ${REDIS_PASSWORD}
 
   # 4. OAuth2 설정
@@ -111,3 +111,14 @@ cloud:
       static: ap-northeast-2 # 서울 리전
     s3:
       bucket: safedog-bucket # S3 버킷 이름
+
+management:
+  endpoints:
+    web:
+      exposure:
+        # health: 무중단 배포 스크립트(deploy.sh)가 살아있는지 확인할 때 사용
+        # prometheus: 프로메테우스가 메트릭을 수집할 때 사용
+        include: health, prometheus
+  metrics:
+    tags:
+      application: SafeDogBe


### PR DESCRIPTION
## 🚀 PR 목적 (Background & Why)
- **기존 문제점:** 수동 배포로 인한 휴먼 에러 위험 및 배포 시 발생하는 서비스 다운타임(Downtime) 존재, AWS Access Key 하드코딩으로 인한 보안 취약점 존재.
- **해결 방안:** GitHub Actions와 AWS OIDC를 연동하여 자격 증명 보안을 강화하고, Nginx 기반의 무중단 배포(Blue/Green) 파이프라인을 구축하여 사용자 경험을 개선합니다. 추가로 Cloudflare를 통한 HTTPS 적용 및 Prometheus/Grafana 모니터링 환경을 통합 구성했습니다.

## 🛠️ 주요 작업 내용 (Key Changes)
### 1. CI/CD 파이프라인 구축 (GitHub Actions -> ECR -> EC2)
- `ci.yml`: AWS OIDC(OpenID Connect)를 사용하여 안전하게 AWS 임시 권한을 획득하고, Jib을 통해 Spring Boot(Java 21) 이미지를 빌드하여 ECR에 Push 하도록 구성.
- `deploy.sh`: AWS SSM(Session Manager)을 통해 EC2 내부에 원격으로 배포 스크립트를 트리거하도록 CD 환경 자동화.

### 2. 무중단 배포(Blue/Green) 아키텍처 적용
- `docker-compose.yml`: `app-blue`(8081)와 `app-green`(8082) 컨테이너 분리 및 Redis, Nginx, 모니터링 컨테이너 통합.
- Nginx `default.conf` & `service-url.inc`: Docker 내부 리졸버(`127.0.0.11`)를 활용하여 Health Check 통과 시 트래픽을 동적으로 스위칭하는 동적 라우팅 적용.

### 3. 보안 및 설정 관리 고도화
- **HTTPS 적용:** Certbot의 복잡성을 제거하고, Cloudflare 오리진 인증서(15년)를 EC2 내부에 마운트하여 `Full Strict` 모드의 강력한 구간 암호화 적용.
- **AWS Parameter Store 연동:** `application-prod.yml`에 `spring-cloud-aws-parameter-store`를 도입하여, DB 비밀번호 및 JWT 시크릿 키 등을 EC2나 GitHub에 파일로 남기지 않고 AWS 메모리에서 직접 주입받도록 보안 강화.

### 4. 모니터링 (SRE 기반 마련)
- `prometheus.yml`: Blue/Green 컨테이너를 분리하여 타겟팅하고, Spring Boot Actuator(`/actuator/prometheus`)와 연동하여 실시간 메트릭 수집 환경 세팅.

## ⚙️ 사전 요구 사항 및 주의 사항 (Action Required)
- [ ] **AWS Parameter Store:** `/safedog/prod/` 하위에 운영 DB 정보 및 외부 API 키들이 `SecureString`으로 등록되어 있어야 애플리케이션이 정상 구동됩니다.
- [ ] **도메인 DNS:** Cloudflare에 EC2의 탄력적 IP가 프록시(주황색 구름) 모드로 연결되어 있어야 합니다.
- [ ] **IAM 권한:** EC2에 연결된 IAM 역할에 `AmazonSSMReadOnlyAccess` (파라미터 스토어 읽기용) 권한이 필수적으로 추가되어야 합니다.

## 📊 아키텍처 흐름도
[Client] -> (HTTPS) -> [Cloudflare Proxy] -> (HTTPS) -> [EC2 Nginx] -> (HTTP) -> [Blue or Green Spring Boot]