### PR TITLE
Auth 도메인 코드 품질 개선 - 이메일 검증·updateLastLogin 연결·OAuth2 예외처리·HTTP 상태코드·OAuthAccount 엔티티 보강

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/controller/AuthController.java
@@ -18,8 +18,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
+@Validated
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -50,7 +53,7 @@ public class AuthController {
     public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequest request) {
         log.info("[AuthController] signup 요청 email={}, nickname={}", request.getEmail(), request.getNickname());
         authService.signup(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     /**
@@ -100,7 +103,7 @@ public class AuthController {
         String refreshToken = resolveRefreshToken(httpRequest, request);
         authService.logout(refreshToken);
         cookieUtils.deleteTokenCookies(httpResponse);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     /**

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/info/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/info/GoogleOAuth2UserInfo.java
@@ -27,7 +27,9 @@ public class GoogleOAuth2UserInfo implements OAuth2UserInfo {
 
     @Override
     public String getName() {
-        return (String) attributes.get("name");
+        String name = (String) attributes.get("name");
+        // Google이 name을 제공하지 않는 경우 sub(providerId) 기반 닉네임으로 폴백
+        return name != null ? name : getProviderId();
     }
 
     @Override

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/info/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/info/NaverOAuth2UserInfo.java
@@ -1,5 +1,7 @@
 package com.newleaseonlife.SafeDogBe.domain.auth.dto.info;
 
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+
 import java.util.Map;
 
 @SuppressWarnings("unchecked")
@@ -12,7 +14,8 @@ public class NaverOAuth2UserInfo implements OAuth2UserInfo {
         this.attributes = attributes;
         this.response = (Map<String, Object>) attributes.get("response");
         if (this.response == null) {
-            throw new IllegalStateException("Naver 응답에 response가 없습니다.");
+            // Spring Security OAuth2 흐름 내에서 올바르게 처리되도록 OAuth2AuthenticationException 사용
+            throw new OAuth2AuthenticationException("Naver 응답에 response 데이터가 없습니다.");
         }
     }
 
@@ -33,7 +36,9 @@ public class NaverOAuth2UserInfo implements OAuth2UserInfo {
 
     @Override
     public String getName() {
-        return (String) response.get("name");
+        String name = (String) response.get("name");
+        // Naver가 name을 제공하지 않는 경우 providerId 기반 닉네임으로 폴백
+        return name != null ? name : getProviderId();
     }
 
     @Override

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/request/LoginRequest.java
@@ -1,5 +1,6 @@
 package com.newleaseonlife.SafeDogBe.domain.auth.dto.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 import lombok.AllArgsConstructor;
@@ -13,6 +14,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class LoginRequest {
 
+    @Email(message = "올바른 이메일 형식이어야 합니다.")
     @NotBlank(message = "이메일은 필수입니다.")
     private String email;
 

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/request/SignupRequest.java
@@ -3,6 +3,7 @@ package com.newleaseonlife.SafeDogBe.domain.auth.dto.request;
 import com.newleaseonlife.SafeDogBe.domain.term.dto.request.TermAgreementRequest;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
@@ -21,6 +22,7 @@ import java.util.List;
 @Builder
 public class SignupRequest {
 
+    @Email(message = "올바른 이메일 형식이어야 합니다.")
     @NotBlank(message = "이메일은 필수입니다.")
     private String email;
 

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/entity/OAuthAccount.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/entity/OAuthAccount.java
@@ -8,9 +8,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
@@ -26,12 +28,15 @@ import java.time.LocalDateTime;
 @Entity
 @Table(
         name = "oauth_accounts",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "provider_id"})
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_oauth_accounts_provider_provider_id",
+                columnNames = {"provider", "provider_id"}
+        )
 )
 @Getter
 @Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class OAuthAccount {
 
     @Id
@@ -39,6 +44,7 @@ public class OAuthAccount {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_oauth_accounts_user"))
     private User user;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/AuthService.java
@@ -121,6 +121,7 @@ public class AuthService {
             throw new BusinessException(AuthErrorCode.LOGIN_FAILED);
         }
 
+        user.updateLastLogin("LOCAL");
         return issueTokenResponse(user);
     }
 

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/CustomOAuth2UserService.java
@@ -61,13 +61,16 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private User saveOrUpdate(OAuth2UserInfo userInfo) {
         OAuthProvider provider = OAuthProvider.valueOf(userInfo.getProvider().toUpperCase());
 
-        return oauthAccountRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
+        User user = oauthAccountRepository.findByProviderAndProviderId(provider, userInfo.getProviderId())
                 .map(OAuthAccount::getUser)
-                .map(user -> {
-                    log.debug("[CustomOAuth2UserService] 기존 OAuth 계정 로그인 userId={}", user.getId());
-                    return user;
+                .map(u -> {
+                    log.debug("[CustomOAuth2UserService] 기존 OAuth 계정 로그인 userId={}", u.getId());
+                    return u;
                 })
                 .orElseGet(() -> createUserAndOAuthAccount(userInfo, provider));
+
+        user.updateLastLogin(provider.name());
+        return user;
     }
 
     private User createUserAndOAuthAccount(OAuth2UserInfo userInfo, OAuthProvider provider) {


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

(#49)

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

전체 코드 점검에서 발견된 auth 도메인 내 **7개 문제**를 수정
이메일 형식 미검증(보안), `updateLastLogin()` 미연결(기능 누락), OAuth2 NPE 및 예외 흐름 오류(장애), HTTP 상태코드 규약 위반, OAuthAccount 엔티티 설계 결함을 한 브랜치에서 일괄 처리

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

| 파일 | 변경 내용 |
|------|----------|
| `SignupRequest.java` | `email` 필드에 `@Email` 추가 |
| `LoginRequest.java` | `email` 필드에 `@Email` 추가 |
| `AuthService.java` | `login()` — 비밀번호 검증 통과 후 `user.updateLastLogin("LOCAL")` 호출 |
| `CustomOAuth2UserService.java` | `saveOrUpdate()` — 기존/신규 분기 이후 `user.updateLastLogin(provider.name())` 호출, 메서드 구조 리팩토링 |
| `GoogleOAuth2UserInfo.java` | `getName()` — `name`이 null이면 `getProviderId()` 폴백 |
| `NaverOAuth2UserInfo.java` | `getName()` — null 폴백 추가, 생성자 `IllegalStateException` → `OAuth2AuthenticationException` |
| `AuthController.java` | `signup` 200→**201 Created**, `logout` 200→**204 No Content**, 클래스 레벨 `@Validated` 추가 |
| `OAuthAccount.java` | `@JoinColumn` 명시 (FK 이름 포함), `@AllArgsConstructor(PRIVATE)`, 유니크 제약 이름 추가 |

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

### 변경 영향 범위
- **API 동작 변경**:
  - `POST /api/auth/signup` 응답 상태코드 `200 OK` → `201 Created` (클라이언트 수정 필요)
  - `POST /api/auth/logout` 응답 상태코드 `200 OK` → `204 No Content` (클라이언트 수정 필요)
- **DB 사이드 이펙트**:
  - 로그인 시 `users.last_login_at`, `users.last_login_provider` 컬럼이 실제로 갱신되기 시작함. 기존 값은 null 유지.
- **엔티티 DDL 변화**:
  - `oauth_accounts` 테이블의 FK 이름이 JPA DDL 자동 생성 시 `fk_oauth_accounts_user`로 명시됨. 기존 DB를 사용 중이면 마이그레이션 스크립트 확인 필요.