### PR TITLE
Global 패키지 보안·설정·예외 처리 개선 (JWT 필터 상태 검증·CORS·IllegalArgumentException 400·JwtProperties 명확화)

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/common/BaseTimeEntity.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/common/BaseTimeEntity.java
@@ -10,6 +10,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+/**
+ * JPA Auditing 기반 생성/수정 시각 공통 필드.
+ * 상속 엔티티는 created_at, updated_at 컬럼을 가지며, @LastModifiedDate는 더티 체킹 시 자동 갱신된다.
+ */
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/common/dto/response/ImageUploadResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/common/dto/response/ImageUploadResponse.java
@@ -5,10 +5,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/** 이미지 업로드 API 응답. 업로드된 이미지 URL. */
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class ImageUploadResponse {
-  private String imageUrl;
+    private String imageUrl;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/config/JwtProperties.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/config/JwtProperties.java
@@ -6,6 +6,10 @@ import org.springframework.stereotype.Component;
 import lombok.Getter;
 import lombok.Setter;
 
+/**
+ * JWT 설정 프로퍼티. application.yaml의 jwt.* 키와 바인딩된다.
+ * access-token-secret, refresh-token-secret은 환경 변수(JWT_ACCSECRET, JWT_REFSECRET)로 설정 권장.
+ */
 @Getter
 @Setter
 @Component
@@ -16,6 +20,8 @@ public class JwtProperties {
     private String accessTokenSecret;
     /** Refresh Token 서명용 시크릿 (환경 변수 JWT_REFSECRET 권장) */
     private String refreshTokenSecret;
-    private long accessTokenExpiration = 1_800_000L;    // 30분
-    private long refreshTokenExpiration = 1_209_600_000L; // 14일 (CookieUtils REFRESH_TOKEN_MAX_AGE와 동일)
+    /** Access Token 유효 기간(ms). 기본 30분 */
+    private long accessTokenExpiration = 1_800_000L;
+    /** Refresh Token 유효 기간(ms). 기본 14일 (CookieUtils REFRESH_TOKEN_MAX_AGE와 맞출 것) */
+    private long refreshTokenExpiration = 1_209_600_000L;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/config/PasswordEncoderConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+/** 비밀번호 암호화용 PasswordEncoder 빈 제공. BCrypt 사용. (회원가입·로그인 검증에 사용) */
 @Configuration
 public class PasswordEncoderConfig {
 

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/config/SecurityConfig.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/config/SecurityConfig.java
@@ -21,6 +21,10 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
 
+/**
+ * Spring Security 전역 설정.
+ * JWT 필터, OAuth2 로그인, CORS, 인가 경로(permitAll/authenticated)를 구성한다.
+ */
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -31,6 +35,7 @@ public class SecurityConfig {
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
     private final CustomOAuth2UserService customOAuth2UserService;
 
+    /** CORS 설정. 쿠키 인증 허용, 로컬 개발 Origin 및 허용 메서드/헤더 정의. */
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
@@ -45,6 +50,7 @@ public class SecurityConfig {
         return source;
     }
 
+    /** Stateless JWT + OAuth2 로그인, 인가 규칙, JWT 필터 위치 정의. */
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/config/SwaggerConfig.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/config/SwaggerConfig.java
@@ -8,20 +8,22 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/** OpenAPI 3 (Swagger) 문서 설정. 제목·설명·버전·Bearer JWT 스킴 정의. */
 @Configuration
 public class SwaggerConfig {
-  @Bean
-  public OpenAPI openAPI() {
-    return new OpenAPI()
-        .info(new Info()
-            .title("SafeDog (개과천선) API 명세서")
-            .description("반려동물 공동 양육 및 케어 노트를 위한 API")
-            .version("v1.0.0"))
-        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
-        .components(new Components()
-            .addSecuritySchemes("bearerAuth", new SecurityScheme()
-                .type(SecurityScheme.Type.HTTP)
-                .scheme("bearer")
-                .bearerFormat("JWT")));
-  }
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("SafeDog (개과천선) API 명세서")
+                        .description("반려동물 공동 양육 및 케어 노트를 위한 API")
+                        .version("v1.0.0"))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")));
+    }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/ApiCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/ApiCode.java
@@ -2,6 +2,7 @@ package com.newleaseonlife.SafeDogBe.global.error;
 
 import org.springframework.http.HttpStatus;
 
+/** API 오류 코드 공통 규약. HTTP 상태, 숫자 코드, 클라이언트 메시지를 제공한다. */
 public interface ApiCode {
 
     HttpStatus getHttpStatus();

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/BusinessException.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/BusinessException.java
@@ -2,6 +2,10 @@ package com.newleaseonlife.SafeDogBe.global.error;
 
 import lombok.Getter;
 
+/**
+ * 도메인/서비스 계층 비즈니스 예외. ApiCode(HTTP 상태·코드·메시지)와 선택적 상세 메시지를 담는다.
+ * GlobalExceptionHandler에서 잡아 ErrorResponse로 변환해 반환한다.
+ */
 @Getter
 public class BusinessException extends RuntimeException {
 
@@ -20,6 +24,7 @@ public class BusinessException extends RuntimeException {
         this.detailMessage = detailMessage;
     }
 
+    /** 클라이언트에 노출할 메시지. detailMessage가 있으면 사용, 없으면 code.getMessage(). */
     public String resolvedMessage() {
         return (detailMessage == null || detailMessage.isBlank())
                 ? code.getMessage()

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/ErrorResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/ErrorResponse.java
@@ -3,6 +3,7 @@ package com.newleaseonlife.SafeDogBe.global.error;
 import lombok.Builder;
 import lombok.Getter;
 
+/** API 오류 응답 DTO. status(HTTP 상태 코드), code(비즈니스 코드), message(클라이언트 메시지). */
 @Getter
 public class ErrorResponse {
 
@@ -17,6 +18,7 @@ public class ErrorResponse {
         this.message = message;
     }
 
+    /** 편의 팩토리. GlobalExceptionHandler 등에서 사용. */
     public static ErrorResponse of(int status, int code, String message) {
         return new ErrorResponse(status, code, message);
     }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/GlobalExceptionHandler.java
@@ -14,10 +14,15 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
+/**
+ * 전역 예외 처리. 비즈니스 예외·검증 실패·파일 용량·IllegalArgument·기타 예외를
+ * HTTP 상태코드와 ErrorResponse 형식으로 일관되게 반환한다.
+ */
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /** 도메인 비즈니스 예외 (AuthErrorCode, UserErrorCode 등). */
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusiness(BusinessException e) {
         ApiCode code = e.getCode();
@@ -90,6 +95,7 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), code.getCode(), message));
     }
 
+    /** 그 외 미처리 예외 → 500 Server Error. */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleAny(Exception e) {
         log.error("[UnhandledException] 예상치 못한 서버 에러", e);

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/AuthErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/AuthErrorCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 import org.springframework.http.HttpStatus;
 
+/** 인증 도메인 오류 코드 (이메일 중복, 로그인 실패, 리프레시 토큰 무효). */
 @AllArgsConstructor
 @Getter
 public enum AuthErrorCode implements ApiCode {

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/PetErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/PetErrorCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 import org.springframework.http.HttpStatus;
 
+/** 반려동물 도메인 오류 코드 (미존재, 접근 거부, 보호자 중복·미존재 등). */
 @AllArgsConstructor
 @Getter
 public enum PetErrorCode implements ApiCode {

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/PetNoteErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/PetNoteErrorCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 import org.springframework.http.HttpStatus;
 
+/** 반려노트 도메인 오류 코드 (미존재, 접근 거부). */
 @AllArgsConstructor
 @Getter
 public enum PetNoteErrorCode implements ApiCode {

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/PostErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/PostErrorCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 import org.springframework.http.HttpStatus;
 
+/** 게시글 도메인 오류 코드 (미존재, 접근 거부, 카테고리 미존재). */
 @AllArgsConstructor
 @Getter
 public enum PostErrorCode implements ApiCode {

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/TermErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/TermErrorCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 import org.springframework.http.HttpStatus;
 
+/** 약관 도메인 오류 코드 (약관 미존재, 필수 약관 미동의, 이미 동의 등). */
 @AllArgsConstructor
 @Getter
 public enum TermErrorCode implements ApiCode {

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/UserErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/UserErrorCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 
 import org.springframework.http.HttpStatus;
 
+/** 유저 도메인 오류 코드 (미존재, 닉네임 중복, 전화번호·이름 중복, 복구 기간 만료 등). */
 @AllArgsConstructor
 @Getter
 public enum UserErrorCode implements ApiCode {

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/security/CookieUtils.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/security/CookieUtils.java
@@ -9,10 +9,16 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
+/**
+ * 인증 쿠키(access_token, refresh_token) 추가·삭제·읽기.
+ * HttpOnly, SameSite=Lax, path/secure는 설정에 따라 적용. refresh_token은 /api/auth/refresh 경로로만 전송.
+ */
 @Component
 public class CookieUtils {
 
+    /** Access Token 쿠키 이름. path=/. */
     public static final String ACCESS_TOKEN_COOKIE  = "access_token";
+    /** Refresh Token 쿠키 이름. path=/api/auth/refresh 로만 전송. */
     public static final String REFRESH_TOKEN_COOKIE = "refresh_token";
 
     private static final String REFRESH_TOKEN_PATH = "/api/auth/refresh";

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/security/CustomPrincipal.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/security/CustomPrincipal.java
@@ -10,11 +10,16 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
+/**
+ * Spring Security 인증 주체. OAuth2User 구현체로, 도메인 User와 OAuth2 attributes를 함께 보관한다.
+ * JWT 필터·OAuth2 성공 핸들러에서 사용. getAuthorities()는 user.role 기반 ROLE_* 반환.
+ */
 public class CustomPrincipal implements OAuth2User {
 
     private final User user;
     private final Map<String, Object> attributes;
 
+    /** @param attributes null이면 빈 Map으로 저장 */
     public CustomPrincipal(User user, Map<String, Object> attributes) {
         this.user = user;
         this.attributes = attributes != null ? attributes : Collections.emptyMap();
@@ -36,6 +41,7 @@ public class CustomPrincipal implements OAuth2User {
         );
     }
 
+    /** OAuth2User 식별자. 이 프로젝트에서는 이메일 사용. */
     @Override
     public String getName() {
         return user.getEmail();

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/security/JwtAuthenticationFilter.java
@@ -20,6 +20,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Collections;
 
+/**
+ * JWT Access Token 기반 인증 필터.
+ * 쿠키(access_token) 또는 Authorization Bearer 헤더에서 토큰을 추출하고,
+ * 유효하며 해당 유저가 ACTIVE 상태일 때만 SecurityContext에 인증 정보를 설정한다.
+ * 탈퇴(WITHDRAWN)·휴면(INACTIVE) 유저는 인증되지 않는다.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -31,6 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
 
+    /** 쿠키 또는 헤더에서 토큰 추출 → 유효 시 ACTIVE 유저만 인증 설정 → 체인 계속 */
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
@@ -52,7 +59,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    // 1. 쿠키 우선 (웹 브라우저), 2. Authorization 헤더 폴백 (모바일 앱)
+    /**
+     * 요청에서 Access Token 추출. 쿠키(웹) 우선, 없으면 Authorization Bearer 헤더(모바일) 사용.
+     */
     private String resolveToken(HttpServletRequest request) {
         String fromCookie = CookieUtils.readCookie(request, CookieUtils.ACCESS_TOKEN_COOKIE);
         if (StringUtils.hasText(fromCookie)) {

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/security/JwtTokenProvider.java
@@ -16,6 +16,10 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
+/**
+ * JWT Access/Refresh Token 발급·검증·파싱.
+ * JwtProperties의 시크릿과 만료 시간을 사용하며, claim에 userId, email, role, type(access/refresh)을 담는다.
+ */
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
@@ -29,6 +33,7 @@ public class JwtTokenProvider {
 
     private final JwtProperties jwtProperties;
 
+    /** Access Token 생성 (type=access, JwtProperties.accessTokenExpiration 적용). */
     public String createAccessToken(Long userId, String email, UserRole role) {
         return createToken(
                 userId,
@@ -40,6 +45,7 @@ public class JwtTokenProvider {
         );
     }
 
+    /** Refresh Token 생성 (type=refresh, JwtProperties.refreshTokenExpiration 적용). */
     public String createRefreshToken(Long userId, String email, UserRole role) {
         return createToken(
                 userId,
@@ -69,15 +75,18 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    /** Access Token에서 userId claim 추출. */
     public Long getUserIdFromAccessToken(String token) {
         Claims claims = parseToken(token, jwtProperties.getAccessTokenSecret());
         return claims.get(CLAIM_USER_ID, Long.class);
     }
 
+    /** Access Token 서명·만료·type 검증. */
     public boolean validateAccessToken(String token) {
         return validateToken(token, jwtProperties.getAccessTokenSecret(), TOKEN_TYPE_ACCESS);
     }
 
+    /** Refresh Token 서명·만료·type 검증. */
     public boolean validateRefreshToken(String token) {
         return validateToken(token, jwtProperties.getRefreshTokenSecret(), TOKEN_TYPE_REFRESH);
     }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/security/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/security/OAuth2LoginFailureHandler.java
@@ -11,12 +11,16 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 
+/**
+ * OAuth2 로그인 실패 시 리다이렉트. 쿼리 파라미터 error=oauth2_login_failed, message=예외 메시지로 전달.
+ */
 @Component
 public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
     @Value("${app.oauth2.redirect-uri-after-login:/}")
     private String redirectUriAfterLogin;
 
+    /** redirectUriAfterLogin?error=oauth2_login_failed&message=... 로 리다이렉트 */
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/security/OAuth2LoginSuccessHandler.java
@@ -16,6 +16,10 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 
+/**
+ * OAuth2 로그인 성공 시 토큰 발급·쿠키 설정 후 리다이렉트.
+ * AuthService.issueTokenResponse로 Access/Refresh 토큰 발급 후 쿠키에 담고, app.oauth2.redirect-uri-after-login으로 이동.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -27,6 +31,7 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     @Value("${app.oauth2.redirect-uri-after-login:/}")
     private String redirectUriAfterLogin;
 
+    /** 토큰 발급 → 쿠키 추가 → redirectUriAfterLogin으로 리다이렉트 */
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -81,8 +81,8 @@ spring:
 
 # JWT 설정
 jwt:
-  accsecret: ${JWT_ACCSECRET}
-  refsecret: ${JWT_REFSECRET}
+  access-token-secret: ${JWT_ACCSECRET}
+  refresh-token-secret: ${JWT_REFSECRET}
   access-token-expiration: 1800000      # 30분
   refresh-token-expiration: 604800000   # 7일
 


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#51 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

global 패키지 점검 결과 반영: **JWT 필터에서 탈퇴/휴면 유저 인증 차단**, **CORS 설정 추가**, **IllegalArgumentException → 400 처리**, **JwtProperties 필드명 및 설정 키 명확화**, **global 패키지 전반 Javadoc·주석 추가**를 적용

---

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

### 동작·설정 변경

| 파일 | 변경 내용 |
|------|----------|
| `global/security/JwtAuthenticationFilter.java` | `UserStatus.ACTIVE`만 인증 허용 (`.filter(user -> user.getStatus() == UserStatus.ACTIVE)`) + 클래스·메서드 Javadoc |
| `global/config/SecurityConfig.java` | `CorsConfigurationSource` 빈 추가, `http.cors(...)` 적용 + 클래스·Bean Javadoc |
| `global/error/GlobalExceptionHandler.java` | `@ExceptionHandler(IllegalArgumentException.class)` 추가 → 400 Bad Request + 클래스·핸들러 주석 |
| `global/config/JwtProperties.java` | `accsecret` → `accessTokenSecret`, `refsecret` → `refreshTokenSecret` + 클래스·필드 Javadoc |
| `global/security/JwtTokenProvider.java` | getter 호출 변경 + 클래스·주요 메서드 Javadoc |
| `src/main/resources/application-prod.yaml` | `jwt.access-token-secret`, `jwt.refresh-token-secret` 키로 변경 (환경 변수명 동일) |
| `src/main/resources/application-local-README.md` | JWT 설정 예시 및 주석을 새 키명으로 수정 |

### 주석(Javadoc) 추가 (S3Config 제외)

| 영역 | 파일 | 추가 내용 |
|------|------|----------|
| config | `SecurityConfig`, `JwtProperties`, `PasswordEncoderConfig`, `SwaggerConfig` | 클래스·Bean·필드 Javadoc, SwaggerConfig 인덴트 정리 |
| security | `JwtAuthenticationFilter`, `JwtTokenProvider`, `CookieUtils`, `CustomPrincipal`, `OAuth2LoginSuccessHandler`, `OAuth2LoginFailureHandler` | 클래스·주요 메서드·상수 Javadoc |
| error | `GlobalExceptionHandler`, `ApiCode`, `BusinessException`, `ErrorResponse`, `CommonErrorCode`, `AuthErrorCode`, `UserErrorCode`, `TermErrorCode`, `PetErrorCode`, `PetNoteErrorCode`, `PostErrorCode` | 클래스·메서드·enum 클래스 Javadoc |
| common | `BaseTimeEntity`, `ImageUploadResponse` | 클래스 Javadoc, ImageUploadResponse 인덴트 정리 |

---

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

### 동작 영향
- **JWT 필터**: 탈퇴/휴면 유저는 유효한 토큰이 있어도 인증되지 않으며, 이후 요청은 401로 처리.
- **CORS**: 로컬 개발용 Origin만 허용. 운영 도메인 추가 시 `SecurityConfig.corsConfigurationSource()` 내 목록 또는 프로퍼티로 확장 필요.
- **설정 호환**: 환경 변수 `JWT_ACCSECRET`, `JWT_REFSECRET` 이름은 그대로이며, YAML 키만 `access-token-secret`, `refresh-token-secret`로 변경
- 기존에 `jwt.accsecret`/`jwt.refsecret`로만 설정된 환경이 있다면 해당 프로파일 YAML을 새 키로 맞춰야 함.

### 주석 추가 범위
- config·security·error·common 하위 모든 Java 파일에 클래스/인터페이스 Javadoc, 주요 메서드·필드·enum 설명을 추가했습니다. 동작 변경 없음.