### PR TITLE
Petnote 도메인 코드 품질 개선 (인덱스·ensurePetOwnership 정리·@Validated·응답 DTO 주석)

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/controller/PetNoteController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/controller/PetNoteController.java
@@ -15,6 +15,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -33,6 +34,7 @@ import java.util.List;
  * 소유권 검증은 서비스 계층에서 수행(해당 Pet의 소유자만 조회·생성·수정·삭제 가능).
  */
 @Slf4j
+@Validated
 @RestController
 @RequestMapping("/api/pet-notes")
 @RequiredArgsConstructor

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/response/PetNoteResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/response/PetNoteResponse.java
@@ -17,10 +17,16 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class PetNoteResponse {
 
+    /** 반려노트 PK */
     private Long id;
+    /** 대상 반려동물 ID */
     private Long petId;
+    /** 기록 대상일 */
     private LocalDate noteDate;
+    /** 메모 내용 */
     private String content;
+    /** 생성 일시 */
     private LocalDateTime createdAt;
+    /** 수정 일시 */
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/entity/PetNote.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/entity/PetNote.java
@@ -10,6 +10,7 @@ import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -25,7 +26,13 @@ import java.time.LocalDate;
  * 날짜별 반려동물 기록 (반려노트). Pet 1 : N PetNote.
  */
 @Entity
-@Table(name = "pet_notes")
+@Table(
+        name = "pet_notes",
+        indexes = {
+                @Index(name = "idx_pet_notes_pet_id", columnList = "pet_id"),
+                @Index(name = "idx_pet_notes_pet_id_note_date", columnList = "pet_id, note_date")
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PetNote extends BaseTimeEntity {

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/service/PetNoteService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/service/PetNoteService.java
@@ -110,9 +110,12 @@ public class PetNoteService {
                 });
     }
 
-    /** 해당 반려동물이 현재 사용자 소유인지 검증. 아니면 PET_NOT_FOUND 또는 PET_ACCESS_DENIED */
+    /**
+     * 해당 반려동물이 현재 사용자 소유인지 검증.
+     * PetNote.pet은 nullable=false이므로 petId는 항상 non-null.
+     * 소유자가 아니면 PET_NOT_FOUND 또는 PET_ACCESS_DENIED.
+     */
     private void ensurePetOwnership(Long petId, Long userId) {
-        if (petId == null) return;
         if (!petRepository.existsByIdAndUserId(petId, userId)) {
             if (petRepository.findById(petId).isEmpty()) {
                 throw new BusinessException(PetErrorCode.PET_NOT_FOUND);


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호
#55

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

petnote 도메인 개선 반영: **PetNote 테이블 인덱스 추가**, **ensurePetOwnership 불필요한 null 체크 제거**, **PetNoteController @Validated 추가**, **PetNoteResponse 필드 주석 추가**를 적용.
API 동작 변경은 없음.

---

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

| 파일 | 변경 내용 |
|------|----------|
| `domain/petnote/entity/PetNote.java` | `@Table(indexes = { idx_pet_notes_pet_id, idx_pet_notes_pet_id_note_date })` 추가 |
| `domain/petnote/service/PetNoteService.java` | `ensurePetOwnership` 내 `if (petId == null) return` 제거, Javadoc 보완 |
| `domain/petnote/controller/PetNoteController.java` | 클래스 레벨 `@Validated` 추가 |
| `domain/petnote/dto/response/PetNoteResponse.java` | id, petId, noteDate, content, createdAt, updatedAt 필드 주석 추가 |

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?

---

## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

### 동작 영향
- **인덱스**: JPA DDL 자동 생성 시 `pet_notes` 테이블에 인덱스가 생성됩니다. 기존 DB를 사용 중이면 Flyway/Liquibase 등으로 인덱스 DDL 추가 여부 확인 필요.
- **ensurePetOwnership**: `PetNote.pet`이 nullable=false이므로 실제로 null이 들어올 경로가 없어, null 체크 제거는 동작 변화 없음. 오히려 null이 들어오면 NPE로 조기 실패하여 디버깅에 유리함.
- **@Validated**: 요청 바디는 기존대로 `@Valid`로 검증되며, `@RequestParam` 등에 붙이는 제약은 향후 추가 시 `@Validated` 덕분에 동작.
