### PR TITLE
Term 도메인 코드 품질 개선 (유니크 제약 이름·Javadoc·@Validated·DTO/Repository 주석)

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/controller/TermController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/controller/TermController.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,7 +22,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+/** 약관 API. 전체 약관 목록, 내 동의 현황, 약관 일괄 동의. */
 @Slf4j
+@Validated
 @RestController
 @RequestMapping("/api/terms")
 @RequiredArgsConstructor
@@ -29,12 +32,14 @@ public class TermController {
 
     private final TermService termService;
 
+    /** 전체 약관 목록 조회 */
     @GetMapping
     public ResponseEntity<List<TermResponse>> getTerms() {
         log.info("[TermController] 약관 목록 조회");
         return ResponseEntity.ok(termService.getAllTerms());
     }
 
+    /** 내 약관 동의 현황 조회 */
     @GetMapping("/my")
     public ResponseEntity<List<UserTermResponse>> getMyTerms(
             @AuthenticationPrincipal CustomPrincipal principal) {
@@ -42,6 +47,7 @@ public class TermController {
         return ResponseEntity.ok(termService.getUserTerms(principal.getUser().getId()));
     }
 
+    /** 약관 일괄 동의. 필수 약관 포함 검증 후 저장 */
     @PostMapping("/agree")
     public ResponseEntity<List<UserTermResponse>> agreeTerms(
             @AuthenticationPrincipal CustomPrincipal principal,

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/converter/TermConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/converter/TermConverter.java
@@ -9,9 +9,11 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+/** Term·UserTerm 엔티티를 응답 DTO로 변환. */
 @Component
 public class TermConverter {
 
+    /** Term → TermResponse */
     public TermResponse toTermResponse(Term term) {
         return new TermResponse(
                 term.getId(),
@@ -20,12 +22,14 @@ public class TermConverter {
         );
     }
 
+    /** Term 목록 → TermResponse 목록 */
     public List<TermResponse> toTermResponseList(List<Term> terms) {
         return terms.stream()
                 .map(this::toTermResponse)
                 .toList();
     }
 
+    /** UserTerm → UserTermResponse */
     public UserTermResponse toUserTermResponse(UserTerm userTerm) {
         return new UserTermResponse(
                 userTerm.getTerm().getId(),
@@ -36,6 +40,7 @@ public class TermConverter {
         );
     }
 
+    /** UserTerm 목록 → UserTermResponse 목록 */
     public List<UserTermResponse> toUserTermResponseList(List<UserTerm> userTerms) {
         return userTerms.stream()
                 .map(this::toUserTermResponse)

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/dto/request/TermAgreementListRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/dto/request/TermAgreementListRequest.java
@@ -5,6 +5,11 @@ import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
+/**
+ * 약관 일괄 동의 요청. POST /api/terms/agree body.
+ *
+ * @param terms 약관별 동의 요청 목록 (비어있을 수 없음)
+ */
 public record TermAgreementListRequest(
         @NotEmpty(message = "약관 동의 목록은 비어있을 수 없습니다")
         @Valid

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/dto/request/TermAgreementRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/dto/request/TermAgreementRequest.java
@@ -2,6 +2,12 @@ package com.newleaseonlife.SafeDogBe.domain.term.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 
+/**
+ * 약관 1건 동의 요청. POST /api/terms/agree body 내 terms[] 요소.
+ *
+ * @param termId 대상 약관 ID
+ * @param agreed 동의 여부
+ */
 public record TermAgreementRequest(
         @NotNull(message = "약관 ID는 필수입니다")
         Long termId,

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/dto/response/TermResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/dto/response/TermResponse.java
@@ -3,6 +3,13 @@ package com.newleaseonlife.SafeDogBe.domain.term.dto.response;
 import com.newleaseonlife.SafeDogBe.domain.term.entity.Term;
 import com.newleaseonlife.SafeDogBe.domain.term.entity.enums.TermType;
 
+/**
+ * 약관 목록 응답. GET /api/terms 에서 사용.
+ *
+ * @param id       약관 PK
+ * @param type     약관 종류 (SERVICE, PRIVACY, MARKETING)
+ * @param required 필수 동의 여부
+ */
 public record TermResponse(
         Long id,
         TermType type,

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/dto/response/UserTermResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/dto/response/UserTermResponse.java
@@ -5,6 +5,15 @@ import com.newleaseonlife.SafeDogBe.domain.term.entity.enums.TermType;
 
 import java.time.LocalDateTime;
 
+/**
+ * 회원별 약관 동의 현황 응답. GET /api/terms/my, POST /api/terms/agree 에서 사용.
+ *
+ * @param termId    약관 ID
+ * @param termType  약관 종류
+ * @param required  필수 동의 여부
+ * @param agreed    해당 회원의 동의 여부
+ * @param agreedAt  동의 시각 (미동의 시 null)
+ */
 public record UserTermResponse(
         Long termId,
         TermType termType,

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/entity/Term.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/entity/Term.java
@@ -10,14 +10,21 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 약관 마스터 엔티티. 서비스 이용약관, 개인정보처리방침, 마케팅 동의 등 타입별 1건.
+ */
 @Entity
-@Table(name = "terms")
+@Table(
+        name = "terms",
+        uniqueConstraints = @UniqueConstraint(name = "uk_terms_type", columnNames = "type")
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Term {
@@ -26,10 +33,12 @@ public class Term {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /** 약관 종류 (SERVICE, PRIVACY, MARKETING) */
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, unique = true, length = 20)
+    @Column(nullable = false, length = 20)
     private TermType type;
 
+    /** 필수 동의 여부 */
     @Column(nullable = false)
     private boolean required;
 

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/entity/UserTerm.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/entity/UserTerm.java
@@ -42,6 +42,7 @@ public class UserTerm {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /** 동의한 회원 */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
             name = "user_id",
@@ -50,6 +51,7 @@ public class UserTerm {
     )
     private User user;
 
+    /** 대상 약관 */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
             name = "term_id",
@@ -58,9 +60,11 @@ public class UserTerm {
     )
     private Term term;
 
+    /** 동의 여부. 기본값 false */
     @Column(nullable = false)
     private boolean agreed = false;
 
+    /** 동의 시각. 동의 시에만 기록 */
     @Column(name = "agreed_at")
     private LocalDateTime agreedAt;
 

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/entity/enums/TermType.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/entity/enums/TermType.java
@@ -1,7 +1,11 @@
 package com.newleaseonlife.SafeDogBe.domain.term.entity.enums;
 
+/** 약관 종류. terms.type, API 응답에 사용. */
 public enum TermType {
-    SERVICE,    // 서비스 이용약관
-    PRIVACY,    // 개인정보처리방침
-    MARKETING   // 마케팅 동의
+    /** 서비스 이용약관 */
+    SERVICE,
+    /** 개인정보처리방침 */
+    PRIVACY,
+    /** 마케팅 수신 동의 */
+    MARKETING
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/repository/TermRepository.java
@@ -6,7 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
+/** 약관(terms) 영속화. */
 public interface TermRepository extends JpaRepository<Term, Long> {
 
+    /** 필수/선택 여부로 약관 목록 조회 */
     List<Term> findAllByRequired(boolean required);
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/repository/UserTermRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/repository/UserTermRepository.java
@@ -8,11 +8,13 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
+/** 회원-약관 동의(user_terms) 영속화. */
 public interface UserTermRepository extends JpaRepository<UserTerm, Long> {
 
+    /** 해당 회원의 약관별 동의 목록 */
     List<UserTerm> findAllByUserId(Long userId);
 
-    // 필수 약관을 모두 동의했는지 확인
+    /** 해당 회원이 필수 약관을 모두 동의했는지 여부. true면 모두 동의함 */
     @Query("SELECT COUNT(t) = 0 FROM Term t WHERE t.required = true " +
            "AND t.id NOT IN (SELECT ut.term.id FROM UserTerm ut WHERE ut.user.id = :userId AND ut.agreed = true)")
     boolean hasAgreedAllRequiredTerms(@Param("userId") Long userId);

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/service/TermService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/term/service/TermService.java
@@ -25,6 +25,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * 약관 도메인 서비스. 전체 약관 목록 조회, 회원별 동의 현황 조회, 약관 일괄 동의 처리.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -36,17 +39,20 @@ public class TermService {
     private final UserRepository userRepository;
     private final TermConverter termConverter;
 
+    /** 전체 약관 목록 조회 (관리용·회원가입 시 약관 노출용) */
     public List<TermResponse> getAllTerms() {
         log.debug("[TermService] getAllTerms");
         return termConverter.toTermResponseList(termRepository.findAll());
     }
 
+    /** 해당 회원의 약관별 동의 현황 조회 */
     public List<UserTermResponse> getUserTerms(Long userId) {
         log.debug("[TermService] getUserTerms userId={}", userId);
         List<UserTerm> userTerms = userTermRepository.findAllByUserId(userId);
         return termConverter.toUserTermResponseList(userTerms);
     }
 
+    /** 약관 일괄 동의. 필수 약관 미동의 시 REQUIRED_TERM_NOT_AGREED. 기존 UserTerm은 update, 없으면 생성 */
     @Transactional
     public List<UserTermResponse> agreeTerms(Long userId, TermAgreementListRequest request) {
         log.info("[TermService] agreeTerms userId={}", userId);


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#57 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

term 도메인 개선 반영: **Term 테이블 유니크 제약 이름(uk_terms_type) 명시**, **엔티티·서비스·컨트롤러·컨버터·DTO·Repository 전반 Javadoc/주석 추가**, **TermController @Validated 추가**를 적용.
API·비즈니스 로직 변경은 없음.

---

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

| 파일 | 변경 내용 |
|------|----------|
| `domain/term/entity/Term.java` | @Table(uniqueConstraints = uk_terms_type), 클래스·필드 주석 |
| `domain/term/entity/UserTerm.java` | id, user, term, agreed, agreedAt 필드 주석 |
| `domain/term/entity/enums/TermType.java` | 클래스 Javadoc, enum 상수 Javadoc |
| `domain/term/service/TermService.java` | 클래스·getAllTerms/getUserTerms/agreeTerms Javadoc |
| `domain/term/controller/TermController.java` | @Validated, 클래스·메서드 주석 |
| `domain/term/converter/TermConverter.java` | 클래스·toTermResponse/toUserTermResponse 등 Javadoc |
| `domain/term/dto/response/TermResponse.java` | record Javadoc, @param id, type, required |
| `domain/term/dto/response/UserTermResponse.java` | record Javadoc, @param termId, termType, required, agreed, agreedAt |
| `domain/term/dto/request/TermAgreementRequest.java` | record Javadoc, @param termId, agreed |
| `domain/term/dto/request/TermAgreementListRequest.java` | record Javadoc, @param terms |
| `domain/term/repository/TermRepository.java` | 인터페이스·findAllByRequired Javadoc |
| `domain/term/repository/UserTermRepository.java` | 인터페이스·findAllByUserId, hasAgreedAllRequiredTerms Javadoc |

---

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

### 동작 영향
- **유니크 제약**: `type` 컬럼 유니크는 기존과 동일. 제약 이름만 `uk_terms_type`으로 명시됨. JPA DDL 자동 생성 시 반영. 기존 DB 사용 시 마이그레이션에서 제약 이름 변경 여부 확인 필요.
- **@Validated**: 요청 바디는 기존대로 `@Valid`로 검증. `@RequestParam` 등에 제약 추가 시 동작하도록 클래스 레벨 @Validated 추가.
- **주석**: 문서화만 추가, 로직 변경 없음.