### PR TITLE
User 도메인 코드 품질 개선 - @Column unique 중복·주석 보완

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/dto/response/UserResponse.java
@@ -20,14 +20,22 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class UserResponse {
 
+    /** 회원 PK */
     private Long id;
+    /** 이메일 (소셜 전용 가입 시 null 가능) */
     private String email;
+    /** 닉네임 */
     private String nickname;
+    /** 실명 */
     private String name;
+    /** 생년월일 */
     private LocalDate birthDate;
+    /** 가입 경로 (LOCAL / GOOGLE / NAVER / KAKAO) */
     private ProviderType providerType;
+    /** 프로필 이미지 URL */
     private String profileImageUrl;
+    /** 권한 (USER / ADMIN) */
     private UserRole role;
-    /** 온보딩 완료 여부. true 이면 최초 설정 완료로 간주 */
+    /** 온보딩 완료 여부. true이면 최초 설정 완료로 간주 */
     private boolean isOnboardingCompleted;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/entity/User.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/entity/User.java
@@ -53,16 +53,16 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    /** 이메일 (소셜 전용 가입 시 null 가능) */
-    @Column(unique = true, length = 100)
+    /** 이메일 (소셜 전용 가입 시 null 가능). 유니크: uk_users_email */
+    @Column(length = 100)
     private String email;
 
     /** 비밀번호 해시. 평문 저장 금지. 소셜 전용 시 null */
     @Column(length = 255)
     private String password;
 
-    /** 닉네임. 서비스 내 표시명, 중복 불가 */
-    @Column(nullable = false, unique = true, length = 50)
+    /** 닉네임. 서비스 내 표시명. 유니크: uk_users_nickname */
+    @Column(nullable = false, length = 50)
     private String nickname;
 
     /** 실명 (선택) */
@@ -102,11 +102,14 @@ public class User {
     @Column(length = 20)
     private String lastLoginProvider;
 
+    /** 생성 일시. JPA Auditing 자동 기록, 수정 불가 */
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    /** 수정 일시. JPA Auditing 자동 갱신 */
     @LastModifiedDate
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
 
     /** 온보딩(최초 설정) 완료 여부. true 시 온보딩 화면 스킵 */

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/service/UserService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/service/UserService.java
@@ -157,6 +157,7 @@ public class UserService {
             log.warn("[UserService] restore 불가 - 소셜 전용 계정 userId={}", user.getId());
             throw new BusinessException(UserErrorCode.CANNOT_RESTORE);
         }
+        // 비밀번호 불일치 시 USER_NOT_FOUND 반환: "계정이 없다"고 알려 계정 존재 여부 노출 방지 (보안 의도적)
         if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
             log.warn("[UserService] restore 실패 - 비밀번호 불일치 userId={}", user.getId());
             throw new BusinessException(UserErrorCode.USER_NOT_FOUND);


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#59 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

user 도메인 개선 반영: **User 엔티티 `@Column(unique=true)` 중복 제거**, **Auditing 필드 주석 및 nullable 보완**, **`restore()` 보안 주석 명시**, **UserResponse 필드 주석 추가**를 적용.
API·비즈니스 로직 변경은 없음.

---

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

| 파일 | 변경 내용 |
|------|----------|
| `domain/user/entity/User.java` | `email`, `nickname` `@Column(unique=true)` 제거 (`@Table` UniqueConstraint로 통일) |
| `domain/user/entity/User.java` | `createdAt`, `updatedAt` 주석 추가, `updatedAt` `@Column(nullable=false)` 추가 |
| `domain/user/service/UserService.java` | `restore()` 비밀번호 불일치 처리에 보안 의도 주석 명시 |
| `domain/user/dto/response/UserResponse.java` | id, email, nickname, name, birthDate, providerType, profileImageUrl, role 필드 주석 |

---

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

### 동작 영향
- **`@Column(unique=true)` 제거**: 기능 동작은 동일. JPA DDL 자동 생성 시 유니크 제약이 `@Table(uniqueConstraints)` 기준으로만 생성됨. 기존 DB를 사용 중이라면 `@Column(unique=true)`가 생성한 제약 이름과 `@Table` 쪽 이름이 다를 수 있으므로 마이그레이션 스크립트 확인 필요.
- **`updatedAt` nullable=false**: 기존 DB 데이터가 null인 경우 마이그레이션에서 기본값 설정 필요.
- **주석·보안 주석**: 로직 변경 없음. restore() 보안 패턴(비밀번호 오류 → USER_NOT_FOUND)은 기존 동작 유지이며 Auth 도메인 로그인 실패 처리와 동일한 방식.