### PR TITLE
Auth 도메인 버그 수정 및 품질 개선 - NPE·만료토큰·기간불일치·createdAt·주석

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/controller/AuthController.java
@@ -28,6 +28,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 인증 API. 회원가입·로컬 로그인·토큰 갱신·로그아웃·중복 체크.
+ * 토큰은 HttpOnly 쿠키로 발급(쿠키 우선), 바디에도 포함하여 모바일 앱도 지원.
+ */
 @Slf4j
 @Validated
 @RestController
@@ -49,6 +53,7 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
+    /** 회원가입. 이메일·닉네임 중복 검사 + 약관 동의 포함. 201 반환 */
     @PostMapping("/signup")
     public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequest request) {
         log.info("[AuthController] signup 요청 email={}, nickname={}", request.getEmail(), request.getNickname());

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/converter/AuthConverter.java
@@ -4,11 +4,13 @@ import com.newleaseonlife.SafeDogBe.domain.auth.dto.response.TokenResponse;
 
 import org.springframework.stereotype.Component;
 
+/** 인증 관련 엔티티·값 → 응답 DTO 변환 */
 @Component
 public class AuthConverter {
 
     private static final String GRANT_TYPE = "Bearer";
 
+    /** Access/Refresh Token 값을 TokenResponse DTO로 변환 */
     public TokenResponse toTokenResponse(String accessToken, String refreshToken, Long accessTokenExpiresIn) {
         return TokenResponse.builder()
                 .grantType(GRANT_TYPE)

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/request/LoginRequest.java
@@ -8,16 +8,21 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 로컬 로그인 요청. POST /api/auth/login body.
+ */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class LoginRequest {
 
+    /** 이메일 */
     @Email(message = "올바른 이메일 형식이어야 합니다.")
     @NotBlank(message = "이메일은 필수입니다.")
     private String email;
 
+    /** 비밀번호 (평문) */
     @NotBlank(message = "비밀번호는 필수입니다.")
     private String password;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/request/SignupRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/request/SignupRequest.java
@@ -16,26 +16,34 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 import java.util.List;
 
+/**
+ * 회원가입 요청. POST /api/auth/signup body.
+ */
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class SignupRequest {
 
+    /** 이메일. 로그인 ID로 사용 */
     @Email(message = "올바른 이메일 형식이어야 합니다.")
     @NotBlank(message = "이메일은 필수입니다.")
     private String email;
 
+    /** 비밀번호. 평문 전달, 서버에서 해시 저장 */
     @NotBlank(message = "비밀번호는 필수입니다.")
     @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
     private String password;
 
+    /** 닉네임. 서비스 내 표시명 */
     @NotBlank(message = "닉네임은 필수입니다.")
     @Size(max = 50)
     private String nickname;
 
+    /** 생년월일 (선택) */
     private LocalDate birthDate;
 
+    /** 약관 동의 목록. 필수 약관 포함 여부는 서버에서 검증 */
     @NotEmpty(message = "약관 동의 목록은 필수입니다.")
     @Valid
     private List<TermAgreementRequest> terms;

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/response/TokenResponse.java
@@ -5,14 +5,21 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 로그인·토큰 갱신 응답. HttpOnly 쿠키와 함께 바디에도 포함(모바일 호환).
+ */
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class TokenResponse {
 
+    /** 인증 방식. 항상 "Bearer" */
     private String grantType;
+    /** JWT Access Token */
     private String accessToken;
+    /** JWT Refresh Token */
     private String refreshToken;
+    /** Access Token 만료 시간(ms) */
     private Long accessTokenExpiresIn;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/entity/OAuthAccount.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/entity/OAuthAccount.java
@@ -5,6 +5,7 @@ import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
@@ -23,8 +24,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import java.time.LocalDateTime;
 
+/**
+ * 소셜 로그인 계정 연동 정보. provider + providerId 조합이 유일(uk_oauth_accounts_provider_provider_id).
+ * 한 User에 여러 소셜 계정 연동 가능.
+ */
 @Entity
 @Table(
         name = "oauth_accounts",
@@ -37,23 +45,29 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EntityListeners(AuditingEntityListener.class)
 public class OAuthAccount {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /** 연동된 회원 */
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_oauth_accounts_user"))
     private User user;
 
+    /** OAuth 공급자 (GOOGLE, NAVER, KAKAO) */
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private OAuthProvider provider;
 
-    @Column(nullable = false, length = 100)
+    /** 공급자에서 발급한 사용자 고유 ID */
+    @Column(name = "provider_id", nullable = false, length = 100)
     private String providerId;
 
-    @Column(nullable = false)
+    /** 최초 연동 일시. JPA Auditing 자동 기록 */
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/entity/RefreshToken.java
@@ -15,6 +15,10 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+/**
+ * Refresh Token 저장 엔티티. 로그인/갱신 시 1건만 유지(기존 삭제 후 재저장).
+ * expiredAt 기준으로 만료 여부를 판단하며, JWT 서명 검증과 별도로 DB 만료 확인 가능.
+ */
 @Entity
 @Table(name = "refresh_tokens")
 @Getter
@@ -27,18 +31,23 @@ public class RefreshToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /** 토큰 소유자 회원 ID */
     @Column(nullable = false)
     private Long userId;
 
+    /** Refresh Token 문자열 */
     @Column(nullable = false, length = 512)
     private String token;
 
+    /** 만료 일시. isExpired() 로 확인 */
     @Column(nullable = false)
     private LocalDateTime expiredAt;
 
+    /** 발급 일시 */
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
+    /** 현재 시각 기준 만료 여부 */
     public boolean isExpired(LocalDateTime now) {
         return now.isAfter(expiredAt);
     }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/entity/enums/OAuthProvider.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/entity/enums/OAuthProvider.java
@@ -1,7 +1,11 @@
 package com.newleaseonlife.SafeDogBe.domain.auth.entity.enums;
 
+/** OAuth2 공급자. OAuthAccount.provider 컬럼에 저장 */
 public enum OAuthProvider {
+    /** Google OAuth2 */
     GOOGLE,
+    /** Naver OAuth2 */
     NAVER,
+    /** Kakao OAuth2 */
     KAKAO
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/entity/enums/ProviderType.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/entity/enums/ProviderType.java
@@ -1,8 +1,13 @@
 package com.newleaseonlife.SafeDogBe.domain.auth.entity.enums;
 
+/** 회원 가입 경로. User.providerType 컬럼에 저장 */
 public enum ProviderType {
+    /** 이메일+비밀번호 로컬 가입 */
     LOCAL,
+    /** Google 소셜 로그인 */
     GOOGLE,
+    /** Naver 소셜 로그인 */
     NAVER,
+    /** Kakao 소셜 로그인 */
     KAKAO
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/repository/OAuthAccountRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/repository/OAuthAccountRepository.java
@@ -7,9 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
+/** OAuth 계정 연동(oauth_accounts) 영속화 */
 public interface OAuthAccountRepository extends JpaRepository<OAuthAccount, Long> {
 
+    /** provider + providerId로 조회. 소셜 로그인 시 기존 계정 확인용 */
     Optional<OAuthAccount> findByProviderAndProviderId(OAuthProvider provider, String providerId);
 
+    /** userId로 조회. 연동된 소셜 계정 확인용 */
     Optional<OAuthAccount> findByUserId(Long userId);
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/repository/RefreshTokenRepository.java
@@ -6,11 +6,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
+/** Refresh Token 영속화. 토큰 문자열·userId 기준 조회·삭제 */
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
+    /** 토큰 문자열로 조회. 갱신·로그아웃 시 사용 */
     Optional<RefreshToken> findByToken(String token);
 
+    /** userId로 조회. 중복 발급 방지 확인용 */
     Optional<RefreshToken> findByUserId(Long userId);
 
+    /** userId의 기존 토큰 삭제. 새 토큰 발급 전 호출 */
     void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/AuthService.java
@@ -34,12 +34,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * 인증 서비스. 회원가입·로그인·토큰 갱신·로그아웃 처리.
+ * 로컬(이메일+비밀번호) 로그인과 소셜(OAuth2) 로그인 공통으로 토큰 발급.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
-    private static final int REFRESH_TOKEN_VALID_DAYS = 14;
+    /** Refresh Token DB 보관 기간(일). JwtProperties.refreshTokenExpiration과 맞춰야 함 */
+    private static final int REFRESH_TOKEN_VALID_DAYS = 7;
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -49,6 +54,7 @@ public class AuthService {
     private final AuthConverter authConverter;
     private final PasswordEncoder passwordEncoder;
 
+    /** 회원가입. 이메일·닉네임 중복 검사 → User 저장 → 약관 동의 저장 */
     @Transactional
     public void signup(SignupRequest request) {
         log.info("[AuthService] signup email={}, nickname={}", request.getEmail(), request.getNickname());
@@ -75,6 +81,7 @@ public class AuthService {
         log.info("[AuthService] signup 완료 userId={}", user.getId());
     }
 
+    /** 필수 약관 동의 여부 검사 후 UserTerm 일괄 저장 */
     private void saveTermAgreements(User user, List<TermAgreementRequest> termRequests) {
         if (termRequests == null || termRequests.isEmpty()) {
             return;
@@ -107,6 +114,10 @@ public class AuthService {
         log.info("[AuthService] 약관 동의 저장 완료 userId={}, count={}", user.getId(), userTerms.size());
     }
 
+    /**
+     * 로컬 로그인. 이메일로 유저 조회 → 비밀번호 검증 → 토큰 발급.
+     * 소셜 전용 계정(password=null)은 LOGIN_FAILED 처리.
+     */
     @Transactional
     public TokenResponse login(LoginRequest request) {
         log.info("[AuthService] login email={}", request.getEmail());
@@ -115,6 +126,12 @@ public class AuthService {
                     log.warn("[AuthService] login 실패 - 사용자 없음 email={}", request.getEmail());
                     return new BusinessException(AuthErrorCode.LOGIN_FAILED);
                 });
+
+        // 소셜 전용 계정(password null)이 로컬 로그인 시도 → NPE 방지 + 명시적 실패
+        if (user.getPassword() == null || user.getPassword().isBlank()) {
+            log.warn("[AuthService] login 실패 - 소셜 전용 계정 userId={}", user.getId());
+            throw new BusinessException(AuthErrorCode.LOGIN_FAILED);
+        }
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             log.warn("[AuthService] login 실패 - 비밀번호 불일치 userId={}", user.getId());
@@ -125,6 +142,7 @@ public class AuthService {
         return issueTokenResponse(user);
     }
 
+    /** Access/Refresh Token 발급 + DB에 Refresh Token 저장(기존 토큰 삭제 후 재저장) */
     @Transactional
     public TokenResponse issueTokenResponse(User user) {
         log.debug("[AuthService] issueTokenResponse userId={}", user.getId());
@@ -152,6 +170,10 @@ public class AuthService {
         return authConverter.toTokenResponse(accessToken, refreshToken, accessTokenExpiresIn);
     }
 
+    /**
+     * Refresh Token으로 Access/Refresh Token 재발급.
+     * JWT 서명·만료 검증 → DB 존재 확인 → 만료 여부 확인 → 재발급.
+     */
     @Transactional
     public TokenResponse refresh(RefreshTokenRequest request) {
         log.info("[AuthService] refresh 요청");
@@ -166,6 +188,13 @@ public class AuthService {
                     return new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
                 });
 
+        // DB에 저장된 토큰이 만료됐으면 재발급 거부
+        if (storedToken.isExpired(LocalDateTime.now())) {
+            log.warn("[AuthService] refresh 실패 - DB 토큰 만료 userId={}", storedToken.getUserId());
+            refreshTokenRepository.delete(storedToken);
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
         User user = userRepository.findById(storedToken.getUserId())
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
@@ -173,6 +202,7 @@ public class AuthService {
         return issueTokenResponse(user);
     }
 
+    /** 로그아웃. DB에서 Refresh Token 삭제. 쿠키 삭제는 컨트롤러에서 수행 */
     @Transactional
     public void logout(String refreshToken) {
         log.info("[AuthService] logout 요청");

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/config/SecurityConfig.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/config/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
                                 "/api/auth/check-duplicate", "/login/**", "/oauth2/**").permitAll()
                         .requestMatchers("/api/terms", "/api/users/check-nickname", "/api/users/restore").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/prometheus").permitAll() // 헬스 체크, 프로메테우스
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated())
                 .oauth2Login(oauth2 -> oauth2


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#63 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

auth 도메인 버그 3건 수정 + OAuthAccount Auditing 보완 + 전반 주석 추가.
소셜 계정 로컬 로그인 NPE 방어, 만료된 Refresh Token 재발급 차단, Refresh 기간 불일치(14일→7일) 수정

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

 파일 | 변경 내용 |
|------|----------|
| `domain/auth/service/AuthService.java` | `login()`: 소셜 전용 계정(password=null) NPE 방어 → LOGIN_FAILED |
| `domain/auth/service/AuthService.java` | `refresh()`: `storedToken.isExpired()` 체크 추가 → 만료 토큰 재발급 차단 |
| `domain/auth/service/AuthService.java` | `REFRESH_TOKEN_VALID_DAYS`: 14 → 7 (prod.yaml refresh-token-expiration=7일 일치) |
| `domain/auth/service/AuthService.java` | 클래스·메서드 Javadoc 추가 |
| `domain/auth/entity/OAuthAccount.java` | `@EntityListeners`, `@CreatedDate`, `@Column(updatable=false)` 추가, 필드 주석 |
| `domain/auth/entity/RefreshToken.java` | 클래스·필드·`isExpired()` 주석 추가 |
| `domain/auth/entity/enums/ProviderType.java` | 클래스·enum 상수 Javadoc |
| `domain/auth/entity/enums/OAuthProvider.java` | 클래스·enum 상수 Javadoc |
| `domain/auth/controller/AuthController.java` | 클래스·`signup()` 메서드 주석 추가 |
| `domain/auth/converter/AuthConverter.java` | 클래스·메서드 Javadoc |
| `domain/auth/dto/response/TokenResponse.java` | 클래스·필드 주석 |
| `domain/auth/dto/request/SignupRequest.java` | 클래스·필드 주석 |
| `domain/auth/dto/request/LoginRequest.java` | 클래스·필드 주석 |
| `domain/auth/repository/RefreshTokenRepository.java` | 인터페이스·메서드 Javadoc |
| `domain/auth/repository/OAuthAccountRepository.java` | 인터페이스·메서드 Javadoc |

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

### 동작 영향
- **`login()` NPE 방어**: 소셜 전용 계정이 로컬 로그인 시도 시 기존 500(NPE) → 401(LOGIN_FAILED)로 변경. 클라이언트 에러 처리 확인 필요.
- **`refresh()` 만료 토큰 차단**: 기존에는 DB 만료 토큰으로도 재발급 가능했으나, 이제 `isExpired()` 검사 후 차단. 만료 토큰 보유 클라이언트는 재로그인 필요.
- **`REFRESH_TOKEN_VALID_DAYS` 7일 변경**: 기존 14일 보관이었으나 JWT 만료(7일)와 맞춤. 기존 DB에 14일 기준으로 저장된 토큰은 JWT 서명 만료(7일)가 먼저 도래하므로 실질적 동작 변화 없음.
- **`OAuthAccount.createdAt`**: `@CreatedDate` 적용으로 소셜 로그인 시 자동 기록. 기존 null 저장 버그 수정.
