### PR TITLE
Pet 도메인 개선 - profileImageUrl TEXT·updatedAt nullable

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/Pet.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/Pet.java
@@ -29,7 +29,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime; // createdAt, updatedAt 필드 타입
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -75,14 +75,17 @@ public class Pet {
     @Column(nullable = false)
     private boolean isNeutered = false;
 
-    @Column(length = 500)
+    /** 프로필 이미지 URL. S3 URL 길이 대비 TEXT 타입 (User.profileImageUrl과 동일) */
+    @Column(columnDefinition = "TEXT")
     private String profileImageUrl;
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    /** 수정 일시. JPA Auditing 자동 갱신 */
     @LastModifiedDate
+    @Column(nullable = false)
     private LocalDateTime updatedAt;
 
     @Builder


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#65 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

`Pet.profileImageUrl` 컬럼 타입을 `User`와 동일하게 TEXT로 변경하고, `updatedAt`에 `@Column(nullable=false)`를 추가.

---

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

| 파일 | 변경 내용 |
|------|----------|
| `domain/pet/entity/Pet.java` | `profileImageUrl`: `@Column(length=500)` → `@Column(columnDefinition="TEXT")` |
| `domain/pet/entity/Pet.java` | `updatedAt`: `@Column(nullable=false)` 추가, Javadoc 추가 |

---

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

### 동작 영향
- **profileImageUrl 타입 변경**: DDL 자동 생성 시 TEXT 컬럼으로 생성. 기존 DB 운영 중이라면 마이그레이션 필요.
  ```sql
  ALTER TABLE pets MODIFY COLUMN profile_image_url TEXT;
  ```
- **updatedAt nullable=false**: 신규 데이터는 JPA Auditing으로 자동 기록. 기존 DB에 null 데이터가 있다면 마이그레이션 시 기본값 설정 필요.
