### PR TITLE
OAuth2 소셜 회원 탈퇴·복구 처리 (재로그인 시 30일 내 자동 복구 / 초과 시 차단)

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/CustomOAuth2UserService.java
@@ -11,6 +11,7 @@ import com.newleaseonlife.SafeDogBe.domain.auth.repository.OAuthAccountRepositor
 import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
 import com.newleaseonlife.SafeDogBe.domain.user.entity.enums.UserStatus;
 import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
+import com.newleaseonlife.SafeDogBe.domain.user.service.UserService;
 import com.newleaseonlife.SafeDogBe.global.security.CustomPrincipal;
 
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.Period;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
 
@@ -71,8 +74,39 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 })
                 .orElseGet(() -> resolveNewSocialUser(userInfo, provider));
 
+        // 2. 탈퇴 회원 처리: 소셜 재로그인 시 30일 내 자동 복구, 초과 시 차단
+        if (user.getStatus() == UserStatus.WITHDRAWN) {
+            restoreWithdrawnOrThrow(user);
+        }
+
         user.updateLastLogin(provider.name());
         return user;
+    }
+
+    /**
+     * 탈퇴 소셜 회원 재로그인 처리.
+     * 소셜 유저는 비밀번호가 없어 {@code POST /api/users/restore} 이메일+비밀번호 경로를 쓸 수 없으므로
+     * 소셜 재로그인 자체가 복구 수단이다.
+     * <ul>
+     *   <li>탈퇴 후 30일 이내 → 계정 자동 복구(ACTIVE 전환) 후 로그인 진행</li>
+     *   <li>탈퇴 후 30일 초과 → {@code OAuth2AuthenticationException} 발생 → FE 안내</li>
+     * </ul>
+     */
+    private void restoreWithdrawnOrThrow(User user) {
+        LocalDateTime withdrawnAt = user.getWithdrawnAt();
+        if (withdrawnAt == null) {
+            log.warn("[CustomOAuth2UserService] 탈퇴 시각 누락 userId={}", user.getId());
+            throw new OAuth2AuthenticationException("탈퇴된 계정입니다. 고객센터에 문의해 주세요.");
+        }
+        long days = ChronoUnit.DAYS.between(withdrawnAt, LocalDateTime.now());
+        if (days > UserService.RESTORE_AVAILABLE_DAYS) {
+            log.warn("[CustomOAuth2UserService] 복구 기간 만료 userId={}, days={}", user.getId(), days);
+            throw new OAuth2AuthenticationException(
+                    "ACCOUNT_RESTORE_EXPIRED|탈퇴 후 30일이 경과하여 계정을 복구할 수 없습니다."
+            );
+        }
+        log.info("[CustomOAuth2UserService] 탈퇴 소셜 회원 자동 복구 userId={}, withdrawnAt={}", user.getId(), withdrawnAt);
+        user.restore();
     }
 
     /**

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/security/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/security/OAuth2LoginFailureHandler.java
@@ -20,13 +20,41 @@ public class OAuth2LoginFailureHandler extends SimpleUrlAuthenticationFailureHan
     @Value("${app.oauth2.redirect-uri-after-login:/}")
     private String redirectUriAfterLogin;
 
-    /** redirectUriAfterLogin?error=oauth2_login_failed&message=... 로 리다이렉트 */
+    /**
+     * OAuth2 인증 실패 시 FE로 리다이렉트.
+     * 예외 메시지에 {@code "KEY|설명"} 형식이 포함된 경우 error 파라미터를 KEY로 분리하여 전달.
+     * FE는 error 파라미터로 화면을 분기한다.
+     *
+     * <ul>
+     *   <li>{@code error=ACCOUNT_RESTORE_EXPIRED} — 탈퇴 30일 초과, 복구 불가 안내</li>
+     *   <li>{@code error=DUPLICATE_ACCOUNT} — 동일 이름 타 소셜 계정 존재</li>
+     *   <li>{@code error=oauth2_login_failed} — 기타 일반 실패</li>
+     * </ul>
+     */
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
+        String rawMessage = exception.getMessage() != null ? exception.getMessage() : "";
+
+        // "KEY|상세 메시지" 형식 파싱: KEY → error 파라미터, 상세 → message 파라미터
+        String errorCode;
+        String message;
+        if (rawMessage.contains("|")) {
+            String[] parts = rawMessage.split("\\|", 2);
+            errorCode = parts[0];
+            message   = parts[1];
+        } else if (rawMessage.startsWith("DUPLICATE_ACCOUNT:")) {
+            // "DUPLICATE_ACCOUNT:{provider}|..." 는 위 분기에서 처리되지만 혹시 | 없을 때 대비
+            errorCode = "DUPLICATE_ACCOUNT";
+            message   = rawMessage;
+        } else {
+            errorCode = "oauth2_login_failed";
+            message   = rawMessage;
+        }
+
         String targetUrl = UriComponentsBuilder.fromUriString(redirectUriAfterLogin)
-                .queryParam("error", "oauth2_login_failed")
-                .queryParam("message", exception.getMessage())
+                .queryParam("error",   errorCode)
+                .queryParam("message", message)
                 .build()
                 .toUriString();
         getRedirectStrategy().sendRedirect(request, response, targetUrl);


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#71 

---

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

OAuth2 소셜 회원 탈퇴·복구 처리 추가.
- 소셜 재로그인 시 탈퇴(WITHDRAWN) 회원: 30일 이내 자동 복구, 30일 초과 시 로그인 차단.
- OAuth2 실패 시 FE로 전달하는 `error` 파라미터 분리 (ACCOUNT_RESTORE_EXPIRED, DUPLICATE_ACCOUNT 등).

---

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

- **CustomOAuth2UserService**
  - `saveOrUpdate()`: OAuth 회원 조회 후 `User.status == WITHDRAWN`이면 `restoreWithdrawnOrThrow(user)` 호출.
  - `restoreWithdrawnOrThrow(User)`: `withdrawnAt` 기준 30일 이내면 `user.restore()`, 초과 시 `OAuth2AuthenticationException("ACCOUNT_RESTORE_EXPIRED|...")` 발생.
  - `UserService.RESTORE_AVAILABLE_DAYS` 상수 사용으로 복구 가능 일수 일치.
- **OAuth2LoginFailureHandler**
  - 예외 메시지 `"KEY|상세메시지"` 형식 파싱 후, 리다이렉트 시 `error=KEY`, `message=상세메시지`로 전달.
  - FE는 `error` 값(ACCOUNT_RESTORE_EXPIRED, DUPLICATE_ACCOUNT, oauth2_login_failed)으로 분기 가능.

---

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

- 소셜 회원 탈퇴는 기존과 동일하게 `POST /api/users/me/withdraw` 사용 (OWNER 방어 로직 포함).
- 로컬 회원 복구는 `POST /api/users/restore`(이메일+비밀번호), 소셜 전용 회원 복구는 소셜 재로그인만 지원.
- FE는 OAuth2 콜백 실패 시 리다이렉트 쿼리 `error`, `message`를 읽어 "복구 기간 만료" / "동일 계정 존재" 등 안내 문구 표시 가능.