### PR TITLE
[feat]: 소셜 로그인 전용 인증 체계 개편 및 온보딩 가입 완료 로직 구현

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/controller/AuthController.java
@@ -1,12 +1,14 @@
 package com.newleaseonlife.SafeDogBe.domain.auth.controller;
 
+import com.newleaseonlife.SafeDogBe.domain.auth.service.dto.SocialSignupCompleteRequest;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
+import com.newleaseonlife.SafeDogBe.global.error.domain.UserErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import com.newleaseonlife.SafeDogBe.domain.auth.dto.request.CheckDuplicateRequest;
-import com.newleaseonlife.SafeDogBe.domain.auth.dto.request.LoginRequest;
 import com.newleaseonlife.SafeDogBe.domain.auth.dto.request.RefreshTokenRequest;
-import com.newleaseonlife.SafeDogBe.domain.auth.dto.request.SignupRequest;
 import com.newleaseonlife.SafeDogBe.domain.auth.dto.request.SocialLinkRequest;
 import com.newleaseonlife.SafeDogBe.domain.auth.dto.response.DeviceLoginProviderResponse;
 import com.newleaseonlife.SafeDogBe.domain.auth.dto.response.TokenResponse;
@@ -24,7 +26,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.util.StringUtils;
@@ -53,6 +54,7 @@ public class AuthController {
     private final AuthService authService;
     private final UserService userService;
     private final CookieUtils cookieUtils;
+    private final UserRepository userRepository;
 
     @Operation(summary = "전화번호+이름 중복 체크", description = "중복이면 409(기존 소셜 타입 포함 메시지), 없으면 204")
     @GetMapping("/check-duplicate")
@@ -62,24 +64,14 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "이메일 회원가입", description = "이메일·닉네임 중복 검사, 약관 동의 포함. 성공 시 201")
-    @PostMapping("/signup")
-    public ResponseEntity<Void> signup(@Valid @RequestBody SignupRequest request) {
-        log.info("[AuthController] signup 요청 email={}, nickname={}", request.getEmail(), request.getNickname());
-        authService.signup(request);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
-    }
-
-    @Operation(summary = "이메일 로그인", description = "성공 시 HttpOnly 쿠키 + 바디에 토큰 발급")
-    @PostMapping("/login")
-    public ResponseEntity<TokenResponse> login(@Valid @RequestBody LoginRequest request,
-                                               HttpServletResponse response) {
-        log.info("[AuthController] login 요청 email={}", request.getEmail());
-        TokenResponse tokenResponse = authService.login(request);
-        cookieUtils.addAccessTokenCookie(response, tokenResponse.getAccessToken(),
-                tokenResponse.getAccessTokenExpiresIn());
-        cookieUtils.addRefreshTokenCookie(response, tokenResponse.getRefreshToken());
-        return ResponseEntity.ok(tokenResponse);
+    @Operation(summary = "소셜 최초 가입 완료", description = "약관 동의와 초대 코드를 받아 PENDING 상태를 ACTIVE로 전환합니다.")
+    @PostMapping("/social-signup-complete")
+    public ResponseEntity<Void> completeSocialSignup(
+        @AuthenticationPrincipal CustomPrincipal principal,
+        @Valid @RequestBody SocialSignupCompleteRequest request) {
+        log.info("[AuthController] 소셜 가입 완료 요청 userId={}", principal.getUser().getId());
+        authService.completeSocialSignup(principal.getUser().getId(), request);
+        return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "토큰 갱신", description = "쿠키 refresh_token 우선, 없으면 바디에서 읽음. 새 토큰 쿠키+바디 반환")
@@ -96,6 +88,21 @@ public class AuthController {
         cookieUtils.addAccessTokenCookie(httpResponse, tokenResponse.getAccessToken(),
                 tokenResponse.getAccessTokenExpiresIn());
         cookieUtils.addRefreshTokenCookie(httpResponse, tokenResponse.getRefreshToken());
+        return ResponseEntity.ok(tokenResponse);
+    }
+    // 💡 앱스토어 심사 통과를 위한 백도어 API (운영 환경에서는 이메일을 통한 권한 탈취 주의)
+    @Operation(summary = "테스트 계정 로그인 (운영 환경 주의)", description = "앱스토어 심사용 백도어 API")
+    @PostMapping("/test-login")
+    public ResponseEntity<TokenResponse> testLogin(
+        @RequestParam String email, HttpServletResponse response) {
+        log.info("[AuthController] 테스트 로그인 요청 email={}", email);
+        User testUser = userRepository.findByEmail(email)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        TokenResponse tokenResponse = authService.issueTokenResponse(testUser);
+        cookieUtils.addAccessTokenCookie(response, tokenResponse.getAccessToken(), tokenResponse.getAccessTokenExpiresIn());
+        cookieUtils.addRefreshTokenCookie(response, tokenResponse.getRefreshToken());
+
         return ResponseEntity.ok(tokenResponse);
     }
 

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/info/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/info/GoogleOAuth2UserInfo.java
@@ -44,4 +44,9 @@ public class GoogleOAuth2UserInfo implements OAuth2UserInfo {
     public Map<String, Object> getAttributes() {
         return attributes;
     }
+
+    @Override
+    public String getPhoneNumber() {
+        return null;
+    }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/info/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/info/KakaoOAuth2UserInfo.java
@@ -59,4 +59,10 @@ public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
     public Map<String, Object> getAttributes() {
         return attributes;
     }
+
+    @Override
+    public String getPhoneNumber() {
+        if (kakaoAccount == null) return null;
+        return (String) kakaoAccount.get("phone_number");
+    }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/info/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/info/NaverOAuth2UserInfo.java
@@ -63,4 +63,11 @@ public class NaverOAuth2UserInfo implements OAuth2UserInfo {
     public Map<String, Object> getAttributes() {
         return attributes;
     }
+
+    @Override
+    public String getPhoneNumber() {
+        // 네이버는 전화번호를 "mobile" 이라는 키값으로 제공합니다.
+        if (response == null) return null;
+        return (String) response.get("mobile");
+    }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/info/OAuth2UserInfo.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/dto/info/OAuth2UserInfo.java
@@ -13,6 +13,8 @@ public interface OAuth2UserInfo {
 
     String getName();
 
+    String getPhoneNumber();
+
     /** 소셜에서 제공하는 생년월일. 없으면 null. 14세 미만 가입 차단 검증에 사용 */
     LocalDate getBirthDate();
 

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/AuthService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/AuthService.java
@@ -1,25 +1,26 @@
 package com.newleaseonlife.SafeDogBe.domain.auth.service;
 
 import com.newleaseonlife.SafeDogBe.domain.auth.converter.AuthConverter;
-import com.newleaseonlife.SafeDogBe.domain.auth.dto.request.LoginRequest;
 import com.newleaseonlife.SafeDogBe.domain.auth.dto.request.RefreshTokenRequest;
 import com.newleaseonlife.SafeDogBe.domain.auth.dto.request.SignupRequest;
 import com.newleaseonlife.SafeDogBe.domain.auth.dto.request.SocialLinkRequest;
+import com.newleaseonlife.SafeDogBe.domain.auth.dto.response.DeviceLoginProviderResponse;
 import com.newleaseonlife.SafeDogBe.domain.auth.dto.response.TokenResponse;
 import com.newleaseonlife.SafeDogBe.domain.auth.entity.OAuthAccount;
 import com.newleaseonlife.SafeDogBe.domain.auth.entity.RefreshToken;
+import com.newleaseonlife.SafeDogBe.domain.auth.entity.UserDevice;
 import com.newleaseonlife.SafeDogBe.domain.auth.entity.enums.OAuthProvider;
 import com.newleaseonlife.SafeDogBe.domain.auth.entity.enums.ProviderType;
-import com.newleaseonlife.SafeDogBe.domain.auth.dto.response.DeviceLoginProviderResponse;
-import com.newleaseonlife.SafeDogBe.domain.auth.entity.UserDevice;
 import com.newleaseonlife.SafeDogBe.domain.auth.repository.OAuthAccountRepository;
 import com.newleaseonlife.SafeDogBe.domain.auth.repository.RefreshTokenRepository;
 import com.newleaseonlife.SafeDogBe.domain.auth.repository.UserDeviceRepository;
+import com.newleaseonlife.SafeDogBe.domain.auth.service.dto.SocialSignupCompleteRequest;
+import com.newleaseonlife.SafeDogBe.domain.pet.service.InviteCodeService;
+import com.newleaseonlife.SafeDogBe.domain.term.dto.request.TermAgreementListRequest;
 import com.newleaseonlife.SafeDogBe.domain.term.dto.request.TermAgreementRequest;
 import com.newleaseonlife.SafeDogBe.domain.term.entity.Term;
 import com.newleaseonlife.SafeDogBe.domain.term.entity.UserTerm;
-import com.newleaseonlife.SafeDogBe.domain.term.repository.TermRepository;
-import com.newleaseonlife.SafeDogBe.domain.term.repository.UserTermRepository;
+import com.newleaseonlife.SafeDogBe.domain.term.service.TermService;
 import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
 import com.newleaseonlife.SafeDogBe.domain.user.entity.enums.UserStatus;
 import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
@@ -28,173 +29,105 @@ import com.newleaseonlife.SafeDogBe.global.error.domain.AuthErrorCode;
 import com.newleaseonlife.SafeDogBe.global.error.domain.TermErrorCode;
 import com.newleaseonlife.SafeDogBe.global.error.domain.UserErrorCode;
 import com.newleaseonlife.SafeDogBe.global.security.JwtTokenProvider;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.flywaydb.core.internal.util.StringUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
- * 인증 서비스. 회원가입·로그인·토큰 갱신·로그아웃 처리.
- * 로컬(이메일+비밀번호) 로그인과 소셜(OAuth2) 로그인 공통으로 토큰 발급.
+ * 인증 서비스. 회원가입·로그인·토큰 갱신·로그아웃 처리. 로컬(이메일+비밀번호) 로그인과 소셜(OAuth2) 로그인 공통으로 토큰 발급.
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
-    /** Refresh Token DB 보관 기간(일). JwtProperties.refreshTokenExpiration·CookieUtils.REFRESH_TOKEN_MAX_AGE_SECONDS와 맞춰야 함 */
+    /**
+     * Refresh Token DB 보관 기간(일).
+     * JwtProperties.refreshTokenExpiration·CookieUtils.REFRESH_TOKEN_MAX_AGE_SECONDS와 맞춰야 함
+     */
     private static final int REFRESH_TOKEN_VALID_DAYS = 90;
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final OAuthAccountRepository oAuthAccountRepository;
     private final UserDeviceRepository userDeviceRepository;
-    private final TermRepository termRepository;
-    private final UserTermRepository userTermRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthConverter authConverter;
-    private final PasswordEncoder passwordEncoder;
+    private final TermService termService;
+    private final InviteCodeService inviteCodeService;
 
-    /** 회원가입. 이메일·닉네임 중복 검사 → User 저장 → 약관 동의 저장 */
-    @Transactional
-    public void signup(SignupRequest request) {
-        log.info("[AuthService] signup email={}, nickname={}", request.getEmail(), request.getNickname());
-        if (userRepository.existsByEmail(request.getEmail())) {
-            log.warn("[AuthService] signup 실패 - 이메일 중복 email={}", request.getEmail());
-            throw new BusinessException(AuthErrorCode.EMAIL_DUPLICATION);
-        }
-        // 닉네임 정규화: 영문 대문자 → 소문자, 앞뒤 공백 제거
-        String normalizedNickname = request.getNickname().trim().toLowerCase();
-        if (userRepository.existsByNickname(normalizedNickname)) {
-            log.warn("[AuthService] signup 실패 - 닉네임 중복 nickname={}", normalizedNickname);
-            throw new BusinessException(UserErrorCode.NICKNAME_DUPLICATION);
-        }
-        if (request.getBirthDate() != null) {
-            int age = Period.between(request.getBirthDate(), LocalDate.now()).getYears();
-            if (age < 14) {
-                log.warn("[AuthService] signup 실패 - 만 14세 미만 birthDate={}", request.getBirthDate());
-                throw new BusinessException(AuthErrorCode.UNDER_AGE);
-            }
-        }
 
-        User user = User.builder()
-                .email(request.getEmail())
-                .password(passwordEncoder.encode(request.getPassword()))
-                .nickname(normalizedNickname)
-                .birthDate(request.getBirthDate())
-                .status(UserStatus.ACTIVE)
-                .providerType(ProviderType.LOCAL)
-                .build();
-        userRepository.save(user);
-
-        saveTermAgreements(user, request.getTerms());
-        log.info("[AuthService] signup 완료 userId={}", user.getId());
-    }
-
-    /** termId 유효성 검증 → 필수 약관 동의 확인 → UserTerm 일괄 저장 */
-    private void saveTermAgreements(User user, List<TermAgreementRequest> termRequests) {
-        if (termRequests == null || termRequests.isEmpty()) {
-            return;
-        }
-        Map<Long, Boolean> agreementMap = termRequests.stream()
-                .collect(Collectors.toMap(TermAgreementRequest::termId, TermAgreementRequest::agreed));
-
-        // 1단계: 요청된 termId가 실제 존재하는지 먼저 검증
-        List<Term> allTerms = termRepository.findAllById(agreementMap.keySet());
-        if (allTerms.size() != agreementMap.size()) {
-            throw new BusinessException(TermErrorCode.TERM_NOT_FOUND);
-        }
-
-        // 2단계: 필수 약관이 모두 동의됐는지 확인
-        List<Term> requiredTerms = termRepository.findAllByRequired(true);
-        for (Term required : requiredTerms) {
-            Boolean agreed = agreementMap.get(required.getId());
-            if (agreed == null || !agreed) {
-                log.warn("[AuthService] 필수 약관 미동의 termId={}", required.getId());
-                throw new BusinessException(TermErrorCode.REQUIRED_TERM_NOT_AGREED);
-            }
-        }
-
-        List<UserTerm> userTerms = allTerms.stream()
-                .map(term -> UserTerm.builder()
-                        .user(user)
-                        .term(term)
-                        .agreed(agreementMap.get(term.getId()))
-                        .build())
-                .toList();
-        userTermRepository.saveAll(userTerms);
-        log.info("[AuthService] 약관 동의 저장 완료 userId={}, count={}", user.getId(), userTerms.size());
-    }
 
     /**
-     * 로컬 로그인. 이메일로 유저 조회 → 비밀번호 검증 → 토큰 발급.
-     * 소셜 전용 계정(password=null)은 LOGIN_FAILED 처리.
+     * AuthService.java (가입 완료 API 추가)
+     * TermService를 주입받아 약관을 처리하고, 상태를 변경하며, 초대코드가 있다면 처리합니다.
+     * 소셜 가입 후 온보딩(약관 동의 + 초대코드) 완료 처리
      */
     @Transactional
-    public TokenResponse login(LoginRequest request) {
-        log.info("[AuthService] login email={}", request.getEmail());
-        User user = userRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> {
-                    log.warn("[AuthService] login 실패 - 사용자 없음 email={}", request.getEmail());
-                    return new BusinessException(AuthErrorCode.LOGIN_FAILED);
-                });
+    public void completeSocialSignup(Long userId, SocialSignupCompleteRequest request) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        // 소셜 전용 계정(password null)이 로컬 로그인 시도 → NPE 방지 + 명시적 실패
-        if (user.getPassword() == null || user.getPassword().isBlank()) {
-            log.warn("[AuthService] login 실패 - 소셜 전용 계정 userId={}", user.getId());
-            throw new BusinessException(AuthErrorCode.LOGIN_FAILED);
+        if (user.getStatus() != UserStatus.PENDING) {
+            throw new BusinessException(AuthErrorCode.ALREADY_ACTIVE_USER);
         }
 
-        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            log.warn("[AuthService] login 실패 - 비밀번호 불일치 userId={}", user.getId());
-            throw new BusinessException(AuthErrorCode.LOGIN_FAILED);
+        // 1. 약관 동의 처리 (TermService의 로직 재사용 또는 호출)
+        termService.agreeTerms(userId, new TermAgreementListRequest(request.terms()));
+
+        // 2. 초대 코드가 존재하면 Joint Guardian(공동 보호자) 매핑 로직 실행
+        if (StringUtils.hasText(request.inviteCode())) {
+            log.info("[AuthService] 초대 코드 처리 시작: {}", request.inviteCode());
+            // ✅ 기존에 만들어둔 InviteCodeService의 로직을 그대로 재사용하여 연결!
+            inviteCodeService.joinByInviteCode(request.inviteCode(), userId);
         }
 
-        user.updateLastLogin("LOCAL");
-        return issueTokenResponse(user);
+        // 3. 모든 필수 절차가 끝났으므로 ACTIVE 상태로 전환
+        user.activate(); // user.status = UserStatus.ACTIVE;
+        log.info("[AuthService] 정식 회원 전환 완료 userId={}", userId);
     }
 
-    /** Access/Refresh Token 발급 + DB에 Refresh Token 저장(기존 토큰 삭제 후 재저장) */
+
+    /**
+     * Access/Refresh Token 발급 + DB에 Refresh Token 저장(기존 토큰 삭제 후 재저장)
+     */
     @Transactional
     public TokenResponse issueTokenResponse(User user) {
         log.debug("[AuthService] issueTokenResponse userId={}", user.getId());
         String accessToken = jwtTokenProvider.createAccessToken(
-                user.getId(),
-                user.getEmail(),
-                user.getRole()
+            user.getId(),
+            user.getEmail(),
+            user.getRole()
         );
         String refreshToken = jwtTokenProvider.createRefreshToken(
-                user.getId(),
-                user.getEmail(),
-                user.getRole()
+            user.getId(),
+            user.getEmail(),
+            user.getRole()
         );
 
         refreshTokenRepository.deleteByUserId(user.getId());
         LocalDateTime now = LocalDateTime.now();
         refreshTokenRepository.save(RefreshToken.builder()
-                .userId(user.getId())
-                .token(refreshToken)
-                .createdAt(now)
-                .expiredAt(now.plusDays(REFRESH_TOKEN_VALID_DAYS))
-                .build());
+            .userId(user.getId())
+            .token(refreshToken)
+            .createdAt(now)
+            .expiredAt(now.plusDays(REFRESH_TOKEN_VALID_DAYS))
+            .build());
 
         Long accessTokenExpiresIn = jwtTokenProvider.getAccessTokenExpirationMs();
         return authConverter.toTokenResponse(accessToken, refreshToken, accessTokenExpiresIn);
     }
 
     /**
-     * Refresh Token으로 Access/Refresh Token 재발급.
-     * JWT 서명·만료 검증 → DB 존재 확인 → 만료 여부 확인 → 재발급.
+     * Refresh Token으로 Access/Refresh Token 재발급. JWT 서명·만료 검증 → DB 존재 확인 → 만료 여부 확인 → 재발급.
      */
     @Transactional
     public TokenResponse refresh(RefreshTokenRequest request) {
@@ -205,10 +138,10 @@ public class AuthService {
         }
 
         RefreshToken storedToken = refreshTokenRepository.findByToken(request.getRefreshToken())
-                .orElseThrow(() -> {
-                    log.warn("[AuthService] refresh 실패 - 저장된 토큰 없음");
-                    return new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
-                });
+            .orElseThrow(() -> {
+                log.warn("[AuthService] refresh 실패 - 저장된 토큰 없음");
+                return new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+            });
 
         // DB에 저장된 토큰이 만료됐으면 재발급 거부
         if (storedToken.isExpired(LocalDateTime.now())) {
@@ -218,74 +151,78 @@ public class AuthService {
         }
 
         User user = userRepository.findById(storedToken.getUserId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
         refreshTokenRepository.delete(storedToken);
         return issueTokenResponse(user);
     }
 
     /**
-     * 소셜 계정 연결. 이미 로그인된 사용자가 추가 소셜 계정을 연결.
-     * 동일 provider+providerId가 이미 존재하면 SOCIAL_ALREADY_LINKED 예외.
+     * 소셜 계정 연결. 이미 로그인된 사용자가 추가 소셜 계정을 연결. 동일 provider+providerId가 이미 존재하면 SOCIAL_ALREADY_LINKED 예외.
      */
     @Transactional
     public void linkSocialAccount(Long userId, SocialLinkRequest request) {
-        log.info("[AuthService] linkSocialAccount userId={}, provider={}", userId, request.provider());
+        log.info("[AuthService] linkSocialAccount userId={}, provider={}", userId,
+            request.provider());
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
         OAuthProvider provider = request.provider();
-        if (oAuthAccountRepository.findByProviderAndProviderId(provider, request.providerId()).isPresent()) {
-            log.warn("[AuthService] linkSocialAccount 실패 - 이미 연결된 소셜 provider={}, providerId={}", provider, request.providerId());
+        if (oAuthAccountRepository.findByProviderAndProviderId(provider, request.providerId())
+            .isPresent()) {
+            log.warn("[AuthService] linkSocialAccount 실패 - 이미 연결된 소셜 provider={}, providerId={}",
+                provider, request.providerId());
             throw new BusinessException(AuthErrorCode.SOCIAL_ALREADY_LINKED);
         }
 
         OAuthAccount account = OAuthAccount.builder()
-                .user(user)
-                .provider(provider)
-                .providerId(request.providerId())
-                .build();
+            .user(user)
+            .provider(provider)
+            .providerId(request.providerId())
+            .build();
         oAuthAccountRepository.save(account);
         log.info("[AuthService] linkSocialAccount 완료 userId={}, provider={}", userId, provider);
     }
 
     /**
-     * 기기별 마지막 로그인 소셜 타입 기록. 로그인 성공 후 FE가 별도 호출.
-     * 기존 기기 기록이 있으면 갱신, 없으면 신규 생성.
+     * 기기별 마지막 로그인 소셜 타입 기록. 로그인 성공 후 FE가 별도 호출. 기존 기기 기록이 있으면 갱신, 없으면 신규 생성.
      */
     @Transactional
     public DeviceLoginProviderResponse registerDeviceLogin(String deviceId, String provider) {
         log.info("[AuthService] registerDeviceLogin deviceId={}, provider={}", deviceId, provider);
         UserDevice device = userDeviceRepository.findByDeviceId(deviceId)
-                .map(d -> {
-                    d.updateLoginInfo(provider);
-                    return d;
-                })
-                .orElseGet(() -> userDeviceRepository.save(
-                        UserDevice.builder().deviceId(deviceId).lastLoginProvider(provider).build()
-                ));
-        return new DeviceLoginProviderResponse(device.getDeviceId(), device.getLastLoginProvider(), device.getLastLoginAt());
+            .map(d -> {
+                d.updateLoginInfo(provider);
+                return d;
+            })
+            .orElseGet(() -> userDeviceRepository.save(
+                UserDevice.builder().deviceId(deviceId).lastLoginProvider(provider).build()
+            ));
+        return new DeviceLoginProviderResponse(device.getDeviceId(), device.getLastLoginProvider(),
+            device.getLastLoginAt());
     }
 
     /**
-     * 기기별 마지막 로그인 소셜 타입 조회. 비인증 공개 API.
-     * 등록된 기기 없으면 null 반환.
+     * 기기별 마지막 로그인 소셜 타입 조회. 비인증 공개 API. 등록된 기기 없으면 null 반환.
      */
     public DeviceLoginProviderResponse getDeviceLoginProvider(String deviceId) {
         return userDeviceRepository.findByDeviceId(deviceId)
-                .map(d -> new DeviceLoginProviderResponse(d.getDeviceId(), d.getLastLoginProvider(), d.getLastLoginAt()))
-                .orElse(null);
+            .map(d -> new DeviceLoginProviderResponse(d.getDeviceId(), d.getLastLoginProvider(),
+                d.getLastLoginAt()))
+            .orElse(null);
     }
 
-    /** 로그아웃. DB에서 Refresh Token 삭제. 쿠키 삭제는 컨트롤러에서 수행 */
+    /**
+     * 로그아웃. DB에서 Refresh Token 삭제. 쿠키 삭제는 컨트롤러에서 수행
+     */
     @Transactional
     public void logout(String refreshToken) {
         log.info("[AuthService] logout 요청");
         RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken)
-                .orElseThrow(() -> {
-                    log.warn("[AuthService] logout 실패 - 유효하지 않은 refreshToken");
-                    return new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
-                });
+            .orElseThrow(() -> {
+                log.warn("[AuthService] logout 실패 - 유효하지 않은 refreshToken");
+                return new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+            });
         refreshTokenRepository.delete(storedToken);
         log.info("[AuthService] logout 완료 userId={}", storedToken.getUserId());
     }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/CustomOAuth2UserService.java
@@ -141,23 +141,24 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         // 4. 전화번호+이름으로 다른 소셜 계정이 있으면 "동일계정존재" 분기
         //    → 오류 코드를 "DUPLICATE_ACCOUNT:{기존provider}" 형식으로 전달. FE가 파싱해 계정 연결 안내
         String name = userInfo.getName();
-        if (name != null && !name.isBlank()) {
-            userRepository.findFirstByName(name).ifPresent(existing -> {
-                // 이름만으로 부정확할 수 있으므로 providerType이 다를 때만 분기
+        String phone = userInfo.getPhoneNumber();
+
+        if (name != null && phone != null) {
+            userRepository.findByPhoneAndName(phone, name).ifPresent(existing -> {
                 if (existing.getProviderType() != null && !existing.getProviderType().name().equals(provider.name())) {
-                    log.warn("[CustomOAuth2UserService] 동일 이름 타 소셜 계정 감지 name={}, existingProvider={}, newProvider={}",
-                            name, existing.getProviderType(), provider);
+                    log.warn("[CustomOAuth2UserService] 동일 이름/번호 타 소셜 계정 감지 name={}, phone={}, existingProvider={}, newProvider={}",
+                        name, phone, existing.getProviderType(), provider);
                     String existingDesc = existing.getProviderType().getDescription();
                     throw new OAuth2AuthenticationException(
-                            "DUPLICATE_ACCOUNT:" + existing.getProviderType().name()
-                                    + "|" + existingDesc + "로 이미 가입된 계정이 있어요. " + existingDesc + "로 로그인하거나 계정을 연결해 주세요."
+                        "DUPLICATE_ACCOUNT:" + existing.getProviderType().name()
+                            + "|" + existingDesc + "로 이미 가입된 계정이 있어요."
                     );
                 }
             });
         }
 
         // 5. 신규 가입
-        return createUserAndOAuthAccount(userInfo, provider, birthDate, email);
+        return createUserAndOAuthAccount(userInfo, provider, birthDate, email, phone);
     }
 
     /** 기존 User에 새 소셜 OAuthAccount 연결 (계정 통합) */
@@ -172,28 +173,29 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     private User createUserAndOAuthAccount(OAuth2UserInfo userInfo, OAuthProvider provider,
-                                           LocalDate birthDate, String email) {
+        LocalDate birthDate, String email, String phone) {
         if (email == null || email.isBlank()) {
             email = userInfo.getProvider() + "_" + userInfo.getProviderId() + "@safedog.oauth";
         }
         String nickname = (userInfo.getName() != null ? userInfo.getName() : "user")
-                + "_" + UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+            + "_" + UUID.randomUUID().toString().replace("-", "").substring(0, 6);
 
         User newUser = User.builder()
-                .email(email)
-                .nickname(nickname)
-                .name(userInfo.getName())
-                .birthDate(birthDate)
-                .status(UserStatus.ACTIVE)
-                .providerType(ProviderType.valueOf(userInfo.getProvider().toUpperCase()))
-                .build();
+            .email(email)
+            .nickname(nickname)
+            .name(userInfo.getName())
+            .phone(phone) // 전달받은 전화번호 저장 (이후 중복 검증 시 사용됨)
+            .birthDate(birthDate)
+            .status(UserStatus.PENDING)
+            .providerType(ProviderType.valueOf(userInfo.getProvider().toUpperCase()))
+            .build();
         userRepository.save(newUser);
 
         OAuthAccount newAccount = OAuthAccount.builder()
-                .user(newUser)
-                .provider(provider)
-                .providerId(userInfo.getProviderId())
-                .build();
+            .user(newUser)
+            .provider(provider)
+            .providerId(userInfo.getProviderId())
+            .build();
         oauthAccountRepository.save(newAccount);
         log.info("[CustomOAuth2UserService] 신규 OAuth 가입 완료 userId={}, provider={}", newUser.getId(), provider);
 

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/dto/SocialSignupCompleteRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/auth/service/dto/SocialSignupCompleteRequest.java
@@ -1,0 +1,11 @@
+package com.newleaseonlife.SafeDogBe.domain.auth.service.dto;
+
+import com.newleaseonlife.SafeDogBe.domain.term.dto.request.TermAgreementRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record SocialSignupCompleteRequest(
+    @NotEmpty(message = "약관 동의 목록은 필수입니다") @Valid List<TermAgreementRequest> terms,
+    String inviteCode // 초대 코드는 선택(Nullable)
+) {}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/controller/UserController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/controller/UserController.java
@@ -92,14 +92,6 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "회원 복구", description = "탈퇴 후 30일 이내만 가능. 이메일+비밀번호 인증 방식")
-    @PostMapping("/restore")
-    public ResponseEntity<UserResponse> restore(@Valid @RequestBody RestoreRequest request) {
-        log.info("[UserController] restore 요청 email={}", request.email());
-        UserResponse response = userService.restore(request.email(), request.password());
-        return ResponseEntity.ok(response);
-    }
-
     @Operation(summary = "마지막 선택 반려동물 갱신", description = "반려동물 선택 시 호출. 다음 접속 기본값으로 저장")
     /** 마지막으로 선택한 반려동물 ID 갱신. 반려동물 선택 시 호출하여 다음 접속 기본값으로 저장.
      *  petId = 0 또는 파라미터 미전송은 허용하지 않음(양수 필수) */

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/entity/User.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/entity/User.java
@@ -57,9 +57,6 @@ public class User {
     @Column(length = 100)
     private String email;
 
-    /** 비밀번호 해시. 평문 저장 금지. 소셜 전용 시 null */
-    @Column(length = 255)
-    private String password;
 
     /** 닉네임. 서비스 내 표시명. 유니크: uk_users_nickname */
     @Column(nullable = false, length = 50)
@@ -123,17 +120,16 @@ public class User {
     private LocalDateTime withdrawnAt;
 
     @Builder
-    public User(String email, String password, String nickname, String name, String phone,
+    public User(String email, String nickname, String name, String phone,
                 LocalDate birthDate, String profileImageUrl,
                 UserStatus status, UserRole role, ProviderType providerType) {
         this.email = email;
-        this.password = password;
         this.nickname = nickname;
         this.name = name;
         this.phone = phone;
         this.birthDate = birthDate;
         this.profileImageUrl = profileImageUrl;
-        this.status = status != null ? status : UserStatus.ACTIVE;
+        this.status = status != null ? status : UserStatus.PENDING;
         this.role = role != null ? role : UserRole.USER;
         this.providerType = providerType;
     }
@@ -183,5 +179,9 @@ public class User {
     /** 마지막으로 선택한 반려동물 ID 갱신. null 허용 (선택 해제) */
     public void updateLastSelectedPet(Long petId) {
         this.lastSelectedPetId = petId;
+    }
+
+    public void activate() {
+        this.status = UserStatus.ACTIVE;
     }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/entity/enums/UserStatus.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/entity/enums/UserStatus.java
@@ -7,5 +7,8 @@ public enum UserStatus {
     /** 휴면. lastLoginAt 기준 일정 기간 미접속 시 전환, 로그인 시 복구 가능 */
     INACTIVE,
     /** 탈퇴. 로그인 불가, Soft Delete */
-    WITHDRAWN
+    WITHDRAWN,
+    /** 소셜 최초 로그인 시 유저를 PENDING 상태로 저장하고, 프론트에서 약관 동의 + 초대코드를 한 번의 API 요청으로 묶어 처리하여 ACTIVE 상태로 전환 */
+    PENDING
+
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/service/UserService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/service/UserService.java
@@ -38,7 +38,6 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final UserConverter userConverter;
-    private final PasswordEncoder passwordEncoder;
     private final PetGuardianRepository petGuardianRepository;
 
     /** ID로 회원 조회. 없으면 USER_NOT_FOUND */
@@ -158,40 +157,6 @@ public class UserService {
         log.info("[UserService] withdraw 완료 userId={}, withdrawnAt={}", userId, user.getWithdrawnAt());
     }
 
-    /**
-     * 탈퇴 복구(이메일 + 비밀번호). 로그인 불가 상태이므로 비인증 API에서 호출.
-     * 탈퇴 후 30일 이내만 복구 가능. 소셜 전용 계정은 비밀번호가 없으므로 CANNOT_RESTORE.
-     */
-    @Transactional
-    public UserResponse restore(String email, String rawPassword) {
-        log.info("[UserService] restore 요청 email={}", email);
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> {
-                    log.warn("[UserService] restore 실패 - 사용자 없음 email={}", email);
-                    return new BusinessException(UserErrorCode.USER_NOT_FOUND);
-                });
-        if (user.getStatus() != UserStatus.WITHDRAWN || user.getWithdrawnAt() == null) {
-            log.warn("[UserService] restore 불가 - 탈퇴 상태 아님 userId={}", user.getId());
-            throw new BusinessException(UserErrorCode.CANNOT_RESTORE);
-        }
-        long daysSinceWithdraw = ChronoUnit.DAYS.between(user.getWithdrawnAt(), LocalDateTime.now());
-        if (daysSinceWithdraw > RESTORE_AVAILABLE_DAYS) {
-            log.warn("[UserService] restore 불가 - 복구 기간 만료 userId={}, days={}", user.getId(), daysSinceWithdraw);
-            throw new BusinessException(UserErrorCode.RESTORE_PERIOD_EXPIRED);
-        }
-        if (user.getPassword() == null || user.getPassword().isBlank()) {
-            log.warn("[UserService] restore 불가 - 소셜 전용 계정 userId={}", user.getId());
-            throw new BusinessException(UserErrorCode.CANNOT_RESTORE);
-        }
-        // 비밀번호 불일치 시 USER_NOT_FOUND 반환: "계정이 없다"고 알려 계정 존재 여부 노출 방지 (보안 의도적)
-        if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
-            log.warn("[UserService] restore 실패 - 비밀번호 불일치 userId={}", user.getId());
-            throw new BusinessException(UserErrorCode.USER_NOT_FOUND);
-        }
-        user.restore();
-        log.info("[UserService] restore 완료 userId={}", user.getId());
-        return userConverter.toResponse(user);
-    }
 
     /**
      * 탈퇴 복구(회원 ID). 이미 사용자가 식별된 경우(예: 소셜 로그인 콜백에서 WITHDRAWN 사용자 확인 후) 호출.
@@ -202,6 +167,7 @@ public class UserService {
         log.info("[UserService] restore by userId={}", userId);
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
         if (user.getStatus() != UserStatus.WITHDRAWN || user.getWithdrawnAt() == null) {
             throw new BusinessException(UserErrorCode.CANNOT_RESTORE);
         }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/config/SecurityConfig.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.newleaseonlife.SafeDogBe.global.security.JwtAuthenticationFilter;
 import com.newleaseonlife.SafeDogBe.global.security.OAuth2LoginFailureHandler;
 import com.newleaseonlife.SafeDogBe.global.security.OAuth2LoginSuccessHandler;
 
+import com.newleaseonlife.SafeDogBe.global.security.PendingUserCheckFilter;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -35,6 +36,7 @@ public class SecurityConfig {
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final PendingUserCheckFilter pendingUserCheckFilter; // ✅ 필터 이름 변경 적용
 
     /** 허용 CORS Origin 목록. 환경별 application.yaml의 app.cors.allowed-origins에서 주입. */
     @Value("${app.cors.allowed-origins}")
@@ -65,10 +67,10 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/api/auth/signup", "/api/auth/login", "/api/auth/refresh", "/api/auth/logout",
+                                "/api/auth/refresh", "/api/auth/logout",
                                 "/api/auth/check-duplicate", "/api/auth/devices/**",
                                 "/login/**", "/oauth2/**").permitAll()
-                        .requestMatchers("/api/terms", "/api/users/check-nickname", "/api/users/restore").permitAll()
+                        .requestMatchers("/api/terms", "/api/users/check-nickname").permitAll()
                         .requestMatchers("/api/invites/*/join").authenticated() // 참여는 인증 필요
                         .requestMatchers("/api/invites/**").permitAll() // 초대 정보 조회는 비인증 허용
                         .requestMatchers("/h2-console/**").permitAll()
@@ -80,7 +82,11 @@ public class SecurityConfig {
                         .successHandler(oAuth2LoginSuccessHandler)
                         .failureHandler(oAuth2LoginFailureHandler))
                 .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+                // 1번: JWT 토큰으로 인증 (이 필터는 PENDING과 ACTIVE 유저 모두 통과시킴)
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                // 2번: PENDING 유저가 메인 API에 접근하는지 감시 및 차단
+                .addFilterAfter(pendingUserCheckFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/AuthErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/AuthErrorCode.java
@@ -18,7 +18,9 @@ public enum AuthErrorCode implements ApiCode {
     /** 만 14세 미만 가입 차단 */
     UNDER_AGE(HttpStatus.BAD_REQUEST, 400, "만 14세 이상만 가입할 수 있습니다."),
     /** 이미 연결된 소셜 계정 */
-    SOCIAL_ALREADY_LINKED(HttpStatus.CONFLICT, 409, "이미 연결된 소셜 계정입니다.");
+    SOCIAL_ALREADY_LINKED(HttpStatus.CONFLICT, 409, "이미 연결된 소셜 계정입니다."),
+    /** 이미 온보딩을 완료한 회원 */
+    ALREADY_ACTIVE_USER(HttpStatus.CONFLICT, 409, "이미 온보딩을 완료한 계정입니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/security/CookieUtils.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/security/CookieUtils.java
@@ -23,7 +23,8 @@ public class CookieUtils {
 
     private static final String REFRESH_TOKEN_PATH = "/api/auth/refresh";
     // AuthService.REFRESH_TOKEN_VALID_DAYS(7일)과 맞춤
-    private static final int    REFRESH_TOKEN_MAX_AGE_SECONDS = 7 * 24 * 60 * 60; // 7일
+    private static final int    REFRESH_TOKEN_MAX_AGE_SECONDS = 90 * 24 * 60 * 60;
+    // 기획상 90일으로 측정됨, 로그인 성공 시 로그인 90일동안 유지(로그인 할 때 마다 갱신)
 
     @Value("${app.cookie.secure:false}")
     private boolean secure;

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/security/JwtAuthenticationFilter.java
@@ -46,7 +46,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(token) && jwtTokenProvider.validateAccessToken(token)) {
             Long userId = jwtTokenProvider.getUserIdFromAccessToken(token);
             userRepository.findById(userId)
-                    .filter(user -> user.getStatus() == UserStatus.ACTIVE)
+                .filter(user -> user.getStatus() == UserStatus.ACTIVE || user.getStatus() == UserStatus.PENDING)
                     .ifPresent(user -> {
                         CustomPrincipal principal = new CustomPrincipal(user, Collections.emptyMap());
                         UsernamePasswordAuthenticationToken authentication =

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/security/OAuth2LoginSuccessHandler.java
@@ -15,6 +15,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * OAuth2 로그인 성공 시 토큰 발급·쿠키 설정 후 리다이렉트.
@@ -45,6 +46,12 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         log.info("[OAuth2LoginSuccessHandler] 소셜 로그인 성공 - 쿠키 발급 userId={}",
                 principal.getUser().getId());
 
-        getRedirectStrategy().sendRedirect(request, response, redirectUriAfterLogin);
+        // 수정: 유저 상태를 쿼리 파라미터로 붙여서 프론트가 화면 라우팅을 할 수 있게 돕기
+        String status = principal.getUser().getStatus().name(); // ACTIVE or PENDING
+        String targetUrl = UriComponentsBuilder.fromUriString(redirectUriAfterLogin)
+            .queryParam("status", status)
+            .build().toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/security/PendingUserCheckFilter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/security/PendingUserCheckFilter.java
@@ -1,0 +1,83 @@
+package com.newleaseonlife.SafeDogBe.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.enums.UserStatus;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * 약관 동의를 완료하지 않은 PENDING 유저의 핵심 API 접근을 차단하는 보안 필터.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PendingUserCheckFilter extends OncePerRequestFilter {
+
+  private final ObjectMapper objectMapper;
+  private final AntPathMatcher pathMatcher = new AntPathMatcher();
+
+  // PENDING 유저라도 반드시 접근해야 하는 경로 (가입 완료 API, 약관 조회 등)
+  private static final List<String> WHITE_LIST = Arrays.asList(
+      "/api/auth/**",
+      "/api/terms/**",
+      "/swagger-ui/**",
+      "/v3/api-docs/**",
+      "/actuator/**"
+  );
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String requestURI = request.getRequestURI();
+
+    // 1. 화이트리스트에 포함된 경로는 PENDING 검사 없이 통과 (ex. /api/auth/social-signup-complete)
+    if (WHITE_LIST.stream().anyMatch(pattern -> pathMatcher.match(pattern, requestURI))) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    // 2. 인증된 사용자 중 상태가 PENDING인 경우 차단
+    if (authentication != null && authentication.getPrincipal() instanceof CustomPrincipal principal) {
+
+      // 🌟 핵심 변경: isOnboardingCompleted가 아닌 Status를 검사
+      if (principal.getUser().getStatus() == UserStatus.PENDING) {
+        log.warn("[PendingUserCheckFilter] 약관 미동의 유저의 API 접근 차단 userId={}, uri={}",
+            principal.getUser().getId(), requestURI);
+
+        sendErrorResponse(response);
+        return; // 필터 체인 중단 (Controller로 넘어가지 않음)
+      }
+    }
+
+    filterChain.doFilter(request, response);
+  }
+
+  private void sendErrorResponse(HttpServletResponse response) throws IOException {
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403 Forbidden
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding("UTF-8");
+
+    // 프론트엔드가 이 에러코드를 받으면 약관 동의 화면으로 튕겨냄
+    String json = objectMapper.writeValueAsString(
+        java.util.Map.of("code", "TERMS_AGREEMENT_REQUIRED", "message", "약관 동의 및 가입 완료가 필요합니다.")
+    );
+    response.getWriter().write(json);
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호
#73 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>

* 로컬 인증 및 회원가입 기능 제거
* PENDING 상태 기반의 소셜 가입 프로세스 구축
* 보안 필터 체인 고도화
* 공동 보호자 초대 로직 통합
* 기타 개선 사항
* 로그인 유지 기간을 기획서에 맞춰 90일로 조정
* 앱스토어 심사 대응을 위한 테스트 계정 백도어 API(test-login) 추가


## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
