### PR TITLE
반려동물/반려노트/체크리스트 기획서 반영 및 단방향 리팩토링

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/ExcretionRecordController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/ExcretionRecordController.java
@@ -1,0 +1,45 @@
+package com.newleaseonlife.SafeDogBe.domain.care.controller;
+
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.ExcretionRecordRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.ExcretionRecordResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.service.ExcretionRecordService;
+import com.newleaseonlife.SafeDogBe.global.security.CustomPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/** 3월 18일 수정
+ * 배변 기록 API.
+ * 기획서 3: 소변/대변 각각 정상/이상 선택 + 세부 항목 기록.
+ */
+@Tag(name = "ExcretionRecord", description = "배변 기록 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/excretion-records")
+public class ExcretionRecordController {
+
+  private final ExcretionRecordService excretionRecordService;
+
+  @Operation(summary = "배변 기록 등록/수정 (당일만 가능)")
+  @PostMapping
+  public ResponseEntity<ExcretionRecordResponse> saveExcretionRecord(
+      @AuthenticationPrincipal CustomPrincipal principal,
+      @Valid @RequestBody ExcretionRecordRequest request) {
+    return ResponseEntity.ok(
+        excretionRecordService.saveExcretionRecord(principal.getUser().getId(), request));
+  }
+
+  @Operation(summary = "체크리스트 배변 기록 조회")
+  @GetMapping
+  public ResponseEntity<List<ExcretionRecordResponse>> getByChecklist(
+      @RequestParam Long checklistId) {
+    return ResponseEntity.ok(excretionRecordService.getByChecklist(checklistId));
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/WeightRecordController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/WeightRecordController.java
@@ -1,0 +1,49 @@
+package com.newleaseonlife.SafeDogBe.domain.care.controller;
+
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.WeightRecordRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.WeightRecordResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.service.WeightRecordService;
+import com.newleaseonlife.SafeDogBe.global.security.CustomPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/** 3월 18일 수정
+ * 체중 기록 API.
+ * 기획서 3: 보호자가 숫자(kg)를 직접 입력해서 저장.
+ */
+@Tag(name = "WeightRecord", description = "체중 기록 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/weight-records")
+public class WeightRecordController {
+
+  private final WeightRecordService weightRecordService;
+
+  @Operation(summary = "체중 기록 등록/수정")
+  @PostMapping
+  public ResponseEntity<WeightRecordResponse> saveWeightRecord(
+      @AuthenticationPrincipal CustomPrincipal principal,
+      @Valid @RequestBody WeightRecordRequest request) {
+    return ResponseEntity.ok(
+        weightRecordService.saveWeightRecord(principal.getUser().getId(), request));
+  }
+
+  @Operation(summary = "기간 내 체중 이력 조회")
+  @GetMapping
+  public ResponseEntity<List<WeightRecordResponse>> getWeightHistory(
+      @RequestParam Long petId,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+    return ResponseEntity.ok(weightRecordService.getWeightHistory(petId, from, to));
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/ExcretionRecordConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/ExcretionRecordConverter.java
@@ -1,0 +1,38 @@
+package com.newleaseonlife.SafeDogBe.domain.care.converter;
+
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.ExcretionRecordResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyExcretionRecord;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+/**3월 18일 수정 */
+@Component
+public class ExcretionRecordConverter {
+
+  public ExcretionRecordResponse toResponse(DailyExcretionRecord r) {
+    if (r == null) return null;
+    return ExcretionRecordResponse.builder()
+        .id(r.getId())
+        .dailyChecklistId(r.getDailyChecklist().getId())
+        .petId(r.getPet().getId())
+        .recordDate(r.getRecordDate())
+        .excretionType(r.getExcretionType())
+        .excretionTypeDescription(r.getExcretionType().getDescription())
+        .isNormal(r.isNormal())
+        .urineCount(r.getUrineCount())
+        .urineColor(r.getUrineColor())
+        .isUrineAccident(r.getIsUrineAccident())
+        .fecesCount(r.getFecesCount())
+        .fecesCondition(r.getFecesCondition())
+        .recordedByUserId(r.getRecordedBy() != null ? r.getRecordedBy().getId() : null)
+        .recordedByNickname(r.getRecordedBy() != null ? r.getRecordedBy().getNickname() : null)
+        .updatedAt(r.getUpdatedAt())
+        .build();
+  }
+
+  public List<ExcretionRecordResponse> toResponseList(List<DailyExcretionRecord> list) {
+    if (list == null || list.isEmpty()) return Collections.emptyList();
+    return list.stream().map(this::toResponse).toList();
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/WeightRecordConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/WeightRecordConverter.java
@@ -1,0 +1,31 @@
+package com.newleaseonlife.SafeDogBe.domain.care.converter;
+
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.WeightRecordResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyWeightRecord;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+
+/** 3월 18일 수정*/
+@Component
+public class WeightRecordConverter {
+
+  public WeightRecordResponse toResponse(DailyWeightRecord r) {
+    if (r == null) return null;
+    return WeightRecordResponse.builder()
+        .id(r.getId())
+        .petId(r.getPet().getId())
+        .recordDate(r.getRecordDate())
+        .weight(r.getWeight())
+        .recordedByUserId(r.getRecordedBy() != null ? r.getRecordedBy().getId() : null)
+        .recordedByNickname(r.getRecordedBy() != null ? r.getRecordedBy().getNickname() : null)
+        .updatedAt(r.getUpdatedAt())
+        .build();
+  }
+
+  public List<WeightRecordResponse> toResponseList(List<DailyWeightRecord> list) {
+    if (list == null || list.isEmpty()) return Collections.emptyList();
+    return list.stream().map(this::toResponse).toList();
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/ExcretionRecordRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/ExcretionRecordRequest.java
@@ -1,0 +1,44 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.request;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.ExcretionType;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+/** 3월 18일 수정
+ * 배변 기록 등록/수정 요청.
+ *
+ * [소변 정상] isNormal=true → urineCount 필수
+ * [소변 이상] isNormal=false → urineCount + urineColor + isUrineAccident 필수
+ * [대변 정상] isNormal=true → fecesCount 필수
+ * [대변 이상] isNormal=false → fecesCount + fecesCondition 필수
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExcretionRecordRequest {
+
+  @NotNull(message = "체크리스트 ID는 필수입니다.")
+  private Long dailyChecklistId;
+
+  @NotNull(message = "배변 종류는 필수입니다.")
+  private ExcretionType excretionType;
+
+  @NotNull(message = "정상/이상 여부는 필수입니다.")
+  private Boolean isNormal;
+
+  /** 소변 횟수. "1~2", "3~4", "5+" */
+  private String urineCount;
+
+  /** 소변 색상 (이상 시). "맑음", "진함", "혈뇨" */
+  private String urineColor;
+
+  /** 소변 실수 여부 (이상 시) */
+  private Boolean isUrineAccident;
+
+  /** 대변 횟수. "1~2", "3~4", "5+" */
+  private String fecesCount;
+
+  /** 대변 상태 (이상 시). "정상", "묽음", "설사", "혈변" */
+  private String fecesCondition;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/WeightRecordRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/WeightRecordRequest.java
@@ -1,0 +1,27 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.request;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/** 3우러 18일 수정
+ *  체중 기록 등록/수정 요청 */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeightRecordRequest {
+
+  @NotNull(message = "반려동물 ID는 필수입니다.")
+  private Long petId;
+
+  @NotNull(message = "기록 날짜는 필수입니다.")
+  private LocalDate recordDate;
+
+  @NotNull(message = "체중은 필수입니다.")
+  @DecimalMin(value = "0.1", message = "체중은 0.1kg 이상이어야 합니다.")
+  private BigDecimal weight;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/ExcretionRecordResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/ExcretionRecordResponse.java
@@ -1,0 +1,32 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.response;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.ExcretionType;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/** 3월 18일 수정
+ * 배변 기록 응답 DTO */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExcretionRecordResponse {
+
+  private Long id;
+  private Long dailyChecklistId;
+  private Long petId;
+  private LocalDate recordDate;
+  private ExcretionType excretionType;
+  private String excretionTypeDescription;
+  private boolean isNormal;
+  private String urineCount;
+  private String urineColor;
+  private Boolean isUrineAccident;
+  private String fecesCount;
+  private String fecesCondition;
+  private Long recordedByUserId;
+  private String recordedByNickname;
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/WeightRecordResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/WeightRecordResponse.java
@@ -1,0 +1,24 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.response;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/** 3월 18일 수정
+ * 체중 기록 응답 DTO */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeightRecordResponse {
+
+  private Long id;
+  private Long petId;
+  private LocalDate recordDate;
+  private BigDecimal weight;
+  private Long recordedByUserId;
+  private String recordedByNickname;
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/DailyExcretionRecord.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/DailyExcretionRecord.java
@@ -1,0 +1,142 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.ExcretionType;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 3월 18일 일일 배변 상세 기록.
+ * <p>
+ * ✅ 신규: DailyChecklist.isCompleted만으로는 배변 상태 저장 불가
+ * <p>
+ * [소변 정상] → urineCount 필수 [소변 이상] → urineCount + urineColor + isUrineAccident 필수 [대변 정상] →
+ * fecesCount 필수 [대변 이상] → fecesCount + fecesCondition 필수
+ */
+@Entity
+@Table(
+    name = "daily_excretion_record",
+    indexes = {
+        @Index(name = "idx_excretion_checklist", columnList = "daily_checklist_id"),
+        @Index(name = "idx_excretion_pet_date", columnList = "pet_id, record_date")
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class DailyExcretionRecord {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "daily_checklist_id", nullable = false,
+      foreignKey = @ForeignKey(name = "fk_excretion_checklist"))
+  private DailyChecklist dailyChecklist;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "pet_id", nullable = false,
+      foreignKey = @ForeignKey(name = "fk_excretion_pet"))
+  private com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet pet;
+
+  @Column(nullable = false)
+  private LocalDate recordDate;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 10)
+  private ExcretionType excretionType;
+
+  /**
+   * 정상/이상 여부
+   */
+  @Column(nullable = false)
+  private boolean isNormal;
+
+  // ─── 소변 관련 ────────────────────────────────────────────────
+  /**
+   * 소변 횟수 선택. "1~2", "3~4", "5+"
+   */
+  @Column(length = 10)
+  private String urineCount;
+
+  /**
+   * 소변 색상 (이상 시). "맑음", "진함", "혈뇨"
+   */
+  @Column(length = 20)
+  private String urineColor;
+
+  /**
+   * 소변 실수 여부 (이상 시)
+   */
+  private Boolean isUrineAccident;
+
+  // ─── 대변 관련 ────────────────────────────────────────────────
+  /**
+   * 대변 횟수 선택. "1~2", "3~4", "5+"
+   */
+  @Column(length = 10)
+  private String fecesCount;
+
+  /**
+   * 대변 상태 (이상 시). "정상", "묽음", "설사", "혈변"
+   */
+  @Column(length = 20)
+  private String fecesCondition;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "recorded_by",
+      foreignKey = @ForeignKey(name = "fk_excretion_user"))
+  private User recordedBy;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+  @Builder
+  public DailyExcretionRecord(DailyChecklist dailyChecklist,
+      com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet pet,
+      LocalDate recordDate, ExcretionType excretionType,
+      boolean isNormal,
+      String urineCount, String urineColor, Boolean isUrineAccident,
+      String fecesCount, String fecesCondition,
+      User recordedBy) {
+    this.dailyChecklist = dailyChecklist;
+    this.pet = pet;
+    this.recordDate = recordDate;
+    this.excretionType = excretionType;
+    this.isNormal = isNormal;
+    this.urineCount = urineCount;
+    this.urineColor = urineColor;
+    this.isUrineAccident = isUrineAccident;
+    this.fecesCount = fecesCount;
+    this.fecesCondition = fecesCondition;
+    this.recordedBy = recordedBy;
+  }
+
+  public void update(Boolean isNormal,
+      String urineCount, String urineColor, Boolean isUrineAccident,
+      String fecesCount, String fecesCondition,
+      User recordedBy) {
+    if (isNormal != null) {
+      this.isNormal = isNormal;
+    }
+
+    this.urineCount = urineCount;
+    this.urineColor = urineColor;
+    this.isUrineAccident = isUrineAccident;
+    this.fecesCount = fecesCount;
+    this.fecesCondition = fecesCondition;
+    this.recordedBy = recordedBy;
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/DailyWeightRecord.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/DailyWeightRecord.java
@@ -1,0 +1,73 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity;
+
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/** 수정 3월 18일
+ * 일일 체중 기록.
+ *
+ * ✅ 신규: DailyChecklist.isCompleted만으로는 체중 수치 저장 불가
+ */
+@Entity
+@Table(
+    name = "daily_weight_record",
+    indexes = {
+        @Index(name = "idx_weight_pet_date", columnList = "pet_id, record_date")
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class DailyWeightRecord {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "pet_id", nullable = false,
+      foreignKey = @ForeignKey(name = "fk_weight_pet"))
+  private com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet pet;
+
+  @Column(nullable = false)
+  private LocalDate recordDate;
+
+  /** 체중 (kg). 소수점 1자리 */
+  @Column(nullable = false, precision = 5, scale = 1)
+  private BigDecimal weight;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "recorded_by",
+      foreignKey = @ForeignKey(name = "fk_weight_user"))
+  private User recordedBy;
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+  @Builder
+  public DailyWeightRecord(com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet pet,
+      LocalDate recordDate, BigDecimal weight, User recordedBy) {
+    this.pet = pet;
+    this.recordDate = recordDate;
+    this.weight = weight;
+    this.recordedBy = recordedBy;
+  }
+
+  public void updateWeight(BigDecimal weight, User recordedBy) {
+    this.weight = weight;
+    this.recordedBy = recordedBy;
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/CareType.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/CareType.java
@@ -3,14 +3,29 @@ package com.newleaseonlife.SafeDogBe.domain.care.entity.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/** 수정_3월18일
+ * 케어 타입 (기획서 기준).
+ *
+ * ✅ 변경: SNACK(간식), SUPPLEMENT(영양제), WATER(급수), EXCRETION(배변),
+ *          WEIGHT(체중), GROOMING(미용), MEDICATION(의약복용), PREVENTION(예방/접종),
+ *          DISEASE_CARE(질병케어) 추가
+ * ✅ 변경: MEDICINE → MEDICATION (명칭 통일)
+ * ✅ 제거: BATH (GROOMING의 세부항목으로 이동), HOSPITAL (기획서에 없음)
+ */
 @Getter
 @RequiredArgsConstructor
 public enum CareType {
   MEAL("식사"),
+  SNACK("간식"),
+  SUPPLEMENT("영양제"),
+  WATER("급수"),
+  EXCRETION("배변"),
   WALK("산책"),
-  MEDICINE("약 복용"),
-  BATH("목욕"),
-  HOSPITAL("병원 방문"),
+  WEIGHT("체중"),
+  GROOMING("미용"),
+  MEDICATION("의약복용"),
+  PREVENTION("예방/접종"),
+  DISEASE_CARE("질병케어"),
   ETC("기타");
 
   private final String description;

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/ExcretionType.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/ExcretionType.java
@@ -1,0 +1,15 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** 수정_3월18일
+ * 배변 종류. DailyExcretionRecord.excretionType 컬럼에 저장. */
+@Getter
+@RequiredArgsConstructor
+public enum ExcretionType {
+  URINE("소변"),
+  FECES("대변");
+
+  private final String description;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/FoodType.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/FoodType.java
@@ -3,13 +3,13 @@ package com.newleaseonlife.SafeDogBe.domain.care.entity.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/** 수정_ 3월 18일
+ * 사료 종류. CareTemplateItem.foodType 컬럼에 저장. */
 @Getter
 @RequiredArgsConstructor
-public enum RepeatCycle {
-  NONE("반복 없음"),
-  DAILY("매일"),
-  WEEKLY("매주"),
-  MONTHLY("매월");
+public enum FoodType {
+  DRY("건식"),
+  WET("습식");
 
   private final String description;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/GroomingType.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/GroomingType.java
@@ -1,0 +1,20 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** 수정_3월18일
+ * 미용 케어 종류. CareTemplateItem.groomingType 컬럼에 저장. */
+@Getter
+@RequiredArgsConstructor
+public enum GroomingType {
+  GROOMING("미용"),
+  NAIL("발톱"),
+  BRUSHING("양치"),
+  EAR_CLEANING("귀청소"),
+  BATH("목욕"),
+  ANAL_GLAND("항문낭"),
+  CUSTOM("직접입력");
+
+  private final String description;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/PreventionType.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/PreventionType.java
@@ -1,0 +1,18 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** 수정_ 3월 18일
+ * 예방/접종 종류. CareTemplateItem.preventionType 컬럼에 저장. */
+@Getter
+@RequiredArgsConstructor
+public enum PreventionType {
+  HEARTWORM("심장사상충"),
+  EXTERNAL_PARASITE("외부 기생충"),
+  DEWORMING("종합구충"),
+  RABIES("광견병 주사"),
+  CUSTOM("직접입력");
+
+  private final String description;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/RepeatCycleUnit.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/RepeatCycleUnit.java
@@ -1,0 +1,24 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** 수정_3월18일
+ * 반복 주기 단위. CareTemplate.repeatCycleUnit 컬럼에 저장.
+ * CareTemplate.repeatCycleValue(숫자)와 조합하여 "N일/N월/N년마다" 표현.
+ *
+ * ✅ 신규: 기존 RepeatCycle(NONE/DAILY/WEEKLY/MONTHLY) 대체
+ * 예) repeatCycleValue=1, repeatCycleUnit=DAY → 매일
+ *     repeatCycleValue=7, repeatCycleUnit=DAY → 7일마다
+ *     repeatCycleValue=1, repeatCycleUnit=MONTH → 매월
+ */
+@Getter
+@RequiredArgsConstructor
+public enum RepeatCycleUnit {
+  DAY("일"),
+  WEEK("주"),
+  MONTH("월"),
+  YEAR("년");
+
+  private final String description;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/TimeSlot.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/enums/TimeSlot.java
@@ -1,0 +1,19 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** 수정_3월18일
+ * 케어 시간대. 식사·영양제·급수·산책·의약복용 등에 공통 사용.
+ * CUSTOM 선택 시 CareTemplate.customTimeSlot 필드에 직접 입력값 저장.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum TimeSlot {
+  MORNING("아침"),
+  LUNCH("점심"),
+  EVENING("저녁"),
+  CUSTOM("직접입력");
+
+  private final String description;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/DailyExcretionRecordRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/DailyExcretionRecordRepository.java
@@ -1,0 +1,24 @@
+package com.newleaseonlife.SafeDogBe.domain.care.repository;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyExcretionRecord;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.ExcretionType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+/**3월 18일 수정*/
+public interface DailyExcretionRecordRepository extends JpaRepository<DailyExcretionRecord, Long> {
+
+  /** 특정 체크리스트의 배변 기록 조회 */
+  List<DailyExcretionRecord> findByDailyChecklistId(Long dailyChecklistId);
+
+  /** 당일 특정 종류 배변 기록 조회 (중복 등록 방지) */
+  Optional<DailyExcretionRecord> findByDailyChecklistIdAndExcretionType(
+      Long dailyChecklistId, ExcretionType excretionType);
+
+  /** 반려동물 날짜 기준 배변 기록 목록 */
+  List<DailyExcretionRecord> findByPetIdAndRecordDateOrderByCreatedAtDesc(
+      Long petId, LocalDate recordDate);
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/DailyWeightRecordRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/DailyWeightRecordRepository.java
@@ -1,0 +1,18 @@
+package com.newleaseonlife.SafeDogBe.domain.care.repository;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyWeightRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+/** 3월 18일 수정 */
+public interface DailyWeightRecordRepository extends JpaRepository<DailyWeightRecord, Long> {
+
+  /** 특정 날짜 체중 기록 (당일 1건) */
+  Optional<DailyWeightRecord> findByPetIdAndRecordDate(Long petId, LocalDate recordDate);
+
+  /** 최근 N일 체중 기록 이력 */
+  List<DailyWeightRecord> findByPetIdAndRecordDateBetweenOrderByRecordDateDesc(
+      Long petId, LocalDate from, LocalDate to);
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/ExcretionRecordService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/ExcretionRecordService.java
@@ -1,0 +1,88 @@
+package com.newleaseonlife.SafeDogBe.domain.care.service;
+
+import com.newleaseonlife.SafeDogBe.domain.care.converter.ExcretionRecordConverter;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.ExcretionRecordRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.ExcretionRecordResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyChecklist;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyExcretionRecord;
+import com.newleaseonlife.SafeDogBe.domain.care.repository.DailyChecklistRepository;
+import com.newleaseonlife.SafeDogBe.domain.care.repository.DailyExcretionRecordRepository;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.CareErrorCode;
+import com.newleaseonlife.SafeDogBe.global.error.domain.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+/**
+ * 3월 18일 수정 배변 기록 서비스. 기획서 3: 소변/대변 상태(정상/이상) 및 세부 항목 저장.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExcretionRecordService {
+
+  private final DailyExcretionRecordRepository excretionRecordRepository;
+  private final DailyChecklistRepository checklistRepository;
+  private final UserRepository userRepository;
+  private final ExcretionRecordConverter converter;
+
+  /**
+   * 배변 기록 등록 또는 수정 (당일만 가능)
+   */
+  @Transactional
+  public ExcretionRecordResponse saveExcretionRecord(Long userId, ExcretionRecordRequest req) {
+    DailyChecklist checklist = checklistRepository.findById(req.getDailyChecklistId())
+        .orElseThrow(() -> new BusinessException(CareErrorCode.CHECKLIST_NOT_FOUND));
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+    validateTodayOnly(checklist);
+
+    // ✅ 수정: req.getIsNormal()이 null인 경우 NPE 방지
+    if (req.getIsNormal() == null) {
+      throw new BusinessException(CareErrorCode.CHECKLIST_NOT_FOUND); // 또는 별도 유효성 에러코드
+    }
+
+    DailyExcretionRecord record = excretionRecordRepository
+        .findByDailyChecklistIdAndExcretionType(req.getDailyChecklistId(), req.getExcretionType())
+        .orElseGet(() -> DailyExcretionRecord.builder()
+            .dailyChecklist(checklist)
+            .pet(checklist.getPet())   // ✅ checklist에서 자동 참조
+            .recordDate(checklist.getTargetDate())
+            .excretionType(req.getExcretionType())
+            .isNormal(req.getIsNormal())
+            .build());
+
+    record.update(
+        req.getIsNormal(),  // Boolean → Boolean (DailyExcretionRecord.update 파라미터도 Boolean으로 통일)
+        req.getUrineCount(), req.getUrineColor(), req.getIsUrineAccident(),
+        req.getFecesCount(), req.getFecesCondition(),
+        user
+    );
+    excretionRecordRepository.save(record);
+    return converter.toResponse(record);
+  }
+
+  /**
+   * 특정 체크리스트의 배변 기록 목록
+   */
+  public List<ExcretionRecordResponse> getByChecklist(Long checklistId) {
+    return converter.toResponseList(
+        excretionRecordRepository.findByDailyChecklistId(checklistId));
+  }
+
+  private void validateTodayOnly(DailyChecklist checklist) {
+    LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+    if (!checklist.getTargetDate().equals(today)) {
+      throw new BusinessException(CareErrorCode.CHECKLIST_DATE_NOT_TODAY);
+    }
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/WeightRecordService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/WeightRecordService.java
@@ -1,0 +1,63 @@
+package com.newleaseonlife.SafeDogBe.domain.care.service;
+
+import com.newleaseonlife.SafeDogBe.domain.care.converter.WeightRecordConverter;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.WeightRecordRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.WeightRecordResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyWeightRecord;
+import com.newleaseonlife.SafeDogBe.domain.care.repository.DailyWeightRecordRepository;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetRepository;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.PetErrorCode;
+import com.newleaseonlife.SafeDogBe.global.error.domain.UserErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/** 3월 18일 수정
+ * 체중 기록 서비스.
+ * 기획서 3: 보호자가 체중 수치(kg)를 직접 입력해서 저장.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WeightRecordService {
+
+  private final DailyWeightRecordRepository weightRecordRepository;
+  private final PetRepository petRepository;
+  private final UserRepository userRepository;
+  private final WeightRecordConverter converter;
+
+  /** 체중 기록 등록 또는 수정 */
+  @Transactional
+  public WeightRecordResponse saveWeightRecord(Long userId, WeightRecordRequest req) {
+    Pet pet = petRepository.findById(req.getPetId())
+        .orElseThrow(() -> new BusinessException(PetErrorCode.PET_NOT_FOUND));
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+    // 당일 기록이 있으면 수정, 없으면 신규
+    DailyWeightRecord record = weightRecordRepository
+        .findByPetIdAndRecordDate(req.getPetId(), req.getRecordDate())
+        .orElseGet(() -> DailyWeightRecord.builder()
+            .pet(pet)
+            .recordDate(req.getRecordDate())
+            .build());
+
+    record.updateWeight(req.getWeight(), user);
+    weightRecordRepository.save(record);
+    return converter.toResponse(record);
+  }
+
+  /** 기간 내 체중 이력 조회 */
+  public List<WeightRecordResponse> getWeightHistory(Long petId, LocalDate from, LocalDate to) {
+    return converter.toResponseList(
+        weightRecordRepository.findByPetIdAndRecordDateBetweenOrderByRecordDateDesc(petId, from, to));
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/converter/PetConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/converter/PetConverter.java
@@ -1,58 +1,57 @@
+// domain/pet/converter/PetConverter.java
 package com.newleaseonlife.SafeDogBe.domain.pet.converter;
 
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetGuardianResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.PetGuardian;
-
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-/**
- * Pet · PetGuardian 엔티티 → API 응답 DTO 변환.
+/** 3월 18일 수정
+ * ✅ 추가: weight, isWeightUnknown, registrationNumber,
+ *          isBirthDateUnknown, hasAllergy, allergyDescription 매핑
  */
 @Component
 public class PetConverter {
 
-    /** Pet → PetResponse. 보호자 목록은 별도 API로 조회 */
     public PetResponse toResponse(Pet pet) {
         return PetResponse.builder()
-                .id(pet.getId())
-                .userId(pet.getUser().getId())
-                .name(pet.getName())
-                .species(pet.getSpecies())
-                .breed(pet.getBreed())
-                .birthDate(pet.getBirthDate())
-                .gender(pet.getGender())
-                .isNeutered(pet.isNeutered())
-                .profileImageUrl(pet.getProfileImageUrl())
-                .diseases(pet.getDiseases())
-                .createdAt(pet.getCreatedAt())
-                .updatedAt(pet.getUpdatedAt())
-                .build();
+            .id(pet.getId())
+            .userId(pet.getUser().getId())
+            .name(pet.getName())
+            .species(pet.getSpecies())
+            .breed(pet.getBreed())
+            .birthDate(pet.getBirthDate())
+            .isBirthDateUnknown(pet.isBirthDateUnknown())
+            .gender(pet.getGender())
+            .isNeutered(pet.isNeutered())
+            .weight(pet.getWeight())
+            .isWeightUnknown(pet.isWeightUnknown())
+            .registrationNumber(pet.getRegistrationNumber())
+            .hasAllergy(pet.getHasAllergy())
+            .allergyDescription(pet.getAllergyDescription())
+            .profileImageUrl(pet.getProfileImageUrl())
+            .diseases(pet.getDiseases())
+            .createdAt(pet.getCreatedAt())
+            .updatedAt(pet.getUpdatedAt())
+            .build();
     }
 
-    /** Pet 목록 → PetResponse 목록 */
     public List<PetResponse> toResponseList(List<Pet> pets) {
-        return pets.stream()
-                .map(this::toResponse)
-                .toList();
+        return pets.stream().map(this::toResponse).toList();
     }
 
-    /** PetGuardian → PetGuardianResponse. 보호자 목록·추가 응답에 사용 */
     public PetGuardianResponse toGuardianResponse(PetGuardian guardian) {
         return PetGuardianResponse.builder()
-                .id(guardian.getId())
-                .userId(guardian.getUser().getId())
-                .role(guardian.getRole())
-                .build();
+            .id(guardian.getId())
+            .userId(guardian.getUser().getId())
+            .role(guardian.getRole())
+            .build();
     }
 
-    /** PetGuardian 목록 → PetGuardianResponse 목록 */
     public List<PetGuardianResponse> toGuardianResponseList(List<PetGuardian> guardians) {
-        return guardians.stream()
-                .map(this::toGuardianResponse)
-                .toList();
+        return guardians.stream().map(this::toGuardianResponse).toList();
     }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetCreateRequest.java
@@ -4,19 +4,22 @@ import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetDisease;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.*;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Set;
 
-/**
- * 반려동물 등록 요청. POST /api/pets body.
- * 요청자는 메인 보호자(pet.user)로 저장됨.
+/** 수정 3월 18일
+ * 반려동물 등록 요청.
+ *
+ * ✅ 추가: weight, isWeightUnknown
+ * ✅ 추가: registrationNumber (동물등록번호 15자리)
+ * ✅ 추가: isBirthDateUnknown
+ * ✅ 추가: hasAllergy, allergyDescription
+ * ✅ 변경: diseases 최대 5개 제한 (기획서 step3)
  */
 @Getter
 @Builder
@@ -25,7 +28,7 @@ import java.util.Set;
 public class PetCreateRequest {
 
     @NotBlank(message = "이름은 필수입니다.")
-    @Size(max = 100)
+    @Size(min = 1, max = 20, message = "이름은 1~20자 이내여야 합니다.")
     private String name;
 
     @Size(max = 50)
@@ -34,18 +37,40 @@ public class PetCreateRequest {
     @Size(max = 100)
     private String breed;
 
+    /** 출생일 (isBirthDateUnknown=true이면 null 허용) */
     private LocalDate birthDate;
+
+    /** 출생일 모름 체크박스. true이면 birthDate 무시 */
+    private boolean isBirthDateUnknown = false;
 
     private Gender gender;
 
     private Boolean isNeutered;
 
-    /** 프로필 이미지 URL. Pet 엔티티가 TEXT 타입이므로 길이 제한 없음 */
+    /** 체중 (kg). isWeightUnknown=true이면 null 허용 */
+    private BigDecimal weight;
+
+    /** 체중 모름 체크박스 */
+    private boolean isWeightUnknown = false;
+
+    /**
+     * 동물등록번호. 숫자만, 최대 15자리. 선택.
+     */
+    @Pattern(regexp = "^[0-9]{0,15}$", message = "동물등록번호는 숫자 15자리 이내여야 합니다.")
+    private String registrationNumber;
+
+    /** 알레르기 여부 (있어요/없어요). null이면 미응답 */
+    private Boolean hasAllergy;
+
+    /** 알레르기 직접 입력 내용. hasAllergy=true일 때 사용 */
+    private String allergyDescription;
+
     private String profileImageUrl;
 
     /**
-     * 질병 목록 (선택). 입력 시 해당 질병에 맞는 케어 템플릿이 자동 생성됨.
-     * 예: [DIABETES, ARTHRITIS]
+     * 질병 목록. 최대 5개.
+     * 기획서: 심장병, 신장질환, 암, 안과질환, 쿠싱 증후군, 관절염
      */
+    @Size(max = 5, message = "질병은 최대 5개까지 선택 가능합니다.")
     private Set<PetDisease> diseases;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetUpdateRequest.java
@@ -1,19 +1,21 @@
 package com.newleaseonlife.SafeDogBe.domain.pet.dto.request;
 
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetDisease;
 
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.*;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Set;
 
-/**
- * 반려동물 수정 요청. PATCH /api/pets/{petId} body.
- * null 필드는 변경하지 않음(부분 수정).
+/** 3월 18일 수정
+ * 반려동물 수정 요청. null 필드는 변경하지 않음(부분 수정).
+ *
+ * ✅ 추가: weight, isWeightUnknown, registrationNumber,
+ *          isBirthDateUnknown, hasAllergy, allergyDescription, diseases
  */
 @Getter
 @Builder
@@ -21,7 +23,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class PetUpdateRequest {
 
-    @Size(max = 100)
+    @Size(min = 1, max = 20)
     private String name;
 
     @Size(max = 50)
@@ -31,11 +33,22 @@ public class PetUpdateRequest {
     private String breed;
 
     private LocalDate birthDate;
+    private Boolean isBirthDateUnknown;
 
     private Gender gender;
-
     private Boolean isNeutered;
 
-    /** 프로필 이미지 URL. Pet 엔티티가 TEXT 타입이므로 길이 제한 없음 */
+    private BigDecimal weight;
+    private Boolean isWeightUnknown;
+
+    @Pattern(regexp = "^[0-9]{0,15}$", message = "동물등록번호는 숫자 15자리 이내여야 합니다.")
+    private String registrationNumber;
+
+    private Boolean hasAllergy;
+    private String allergyDescription;
+
     private String profileImageUrl;
+
+    @Size(max = 5, message = "질병은 최대 5개까지 선택 가능합니다.")
+    private Set<PetDisease> diseases;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/response/PetResponse.java
@@ -1,20 +1,20 @@
+// domain/pet/dto/response/PetResponse.java
 package com.newleaseonlife.SafeDogBe.domain.pet.dto.response;
 
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetDisease;
+import lombok.*;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Set;
 
-/**
- * 반려동물 응답. 조회·등록·수정 API 응답에 사용.
- * 보호자 목록은 GET /api/pets/{petId}/guardians 로 별도 조회.
+/** 수정 3월 18일
+ * 반려동물 응답 DTO.
+ *
+ * ✅ 추가: weight, isWeightUnknown, registrationNumber,
+ *          isBirthDateUnknown, hasAllergy, allergyDescription
  */
 @Getter
 @Builder
@@ -23,17 +23,20 @@ import java.util.Set;
 public class PetResponse {
 
     private Long id;
-    /** 메인 보호자(소유자) ID */
     private Long userId;
     private String name;
     private String species;
     private String breed;
     private LocalDate birthDate;
+    private boolean isBirthDateUnknown;
     private Gender gender;
-    /** 중성화 여부 */
     private boolean isNeutered;
+    private BigDecimal weight;
+    private boolean isWeightUnknown;
+    private String registrationNumber;
+    private Boolean hasAllergy;
+    private String allergyDescription;
     private String profileImageUrl;
-    /** 질병 목록. 등록된 질병이 없으면 빈 Set */
     private Set<PetDisease> diseases;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/Pet.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/Pet.java
@@ -4,43 +4,25 @@ import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetDisease;
 import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import jakarta.persistence.*;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
- * 반려동물 엔티티. 메인 보호자(user)와 보호자 목록(guardians)을 가짐.
- * Pet 삭제 시 guardians는 cascade + orphanRemoval로 함께 삭제됨.
+ * 수정 3월 18일 반려동물 엔티티.
+ * <p>
+ * ✅ 추가: weight, isWeightUnknown, registrationNumber, isBirthDateUnknown, hasAllergy,
+ * allergyDescription ✅ 제거: PetDisease.ALLERGY → hasAllergy/allergyDescription 필드로 분리
+ * <p>
+ * ⚠️ 단방향 원칙: - [기존 리팩토링 문서 오류] guardians(@OneToMany) 필드가 있었음 → 제거 - PetGuardian → Pet 단방향
+ * @ManyToOne 유지 - 보호자 조회/삭제는 PetGuardianRepository에서만 처리
  */
 @Entity
 @Table(name = "pets")
@@ -49,86 +31,180 @@ import java.util.Set;
 @EntityListeners(AuditingEntityListener.class)
 public class Pet {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    /** 메인 보호자(소유자). pets.user_id FK */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_pets_user"))
-    private User user;
+  /**
+   * 메인 보호자(소유자). Pet → User 단방향
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_pets_user"))
+  private User user;
 
-    /** 보호자 목록(OWNER, CAREGIVER). Pet 삭제 시 함께 삭제, guardian 제거 시 DB에서도 삭제(orphanRemoval) */
-    @OneToMany(mappedBy = "pet", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PetGuardian> guardians = new ArrayList<>();
+  @Column(nullable = false, length = 100)
+  private String name;
 
-    @Column(nullable = false, length = 100)
-    private String name;
+  /**
+   * 종 (강아지/고양이)
+   */
+  @Column(length = 50)
+  private String species;
 
-    @Column(length = 50)
-    private String species;
+  @Column(length = 100)
+  private String breed;
 
-    @Column(length = 100)
-    private String breed;
+  private LocalDate birthDate;
 
-    private LocalDate birthDate;
+  /**
+   * 출생일을 모르는 경우 true. true이면 birthDate는 null
+   */
+  @Column(nullable = false)
+  private boolean isBirthDateUnknown = false;
 
-    @Enumerated(EnumType.STRING)
-    @Column(length = 10)
-    private Gender gender;
+  @Enumerated(EnumType.STRING)
+  @Column(length = 10)
+  private Gender gender;
 
-    @Column(nullable = false)
-    private boolean isNeutered = false;
+  @Column(nullable = false)
+  private boolean isNeutered = false;
 
-    /** 프로필 이미지 URL. S3 URL 길이 대비 TEXT 타입 (User.profileImageUrl과 동일) */
-    @Column(columnDefinition = "TEXT")
-    private String profileImageUrl;
+  /**
+   * 체중 (kg). 소수점 1자리까지 허용. isWeightUnknown=true이면 null 허용.
+   */
+  @Column(precision = 5, scale = 1)
+  private BigDecimal weight;
 
-    /**
-     * 질병 목록. 등록 시 질병별 CareTemplate 자동 생성에 사용.
-     * pet_diseases 별도 테이블에 저장. 비어있으면 질병 없음.
-     */
-    @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(
-            name = "pet_diseases",
-            joinColumns = @JoinColumn(name = "pet_id", foreignKey = @ForeignKey(name = "fk_pet_diseases_pet"))
-    )
-    @Enumerated(EnumType.STRING)
-    @Column(name = "disease", length = 30, nullable = false)
-    private Set<PetDisease> diseases = new HashSet<>();
+  /**
+   * 체중을 모르는 경우 true. true이면 weight는 null
+   */
+  @Column(nullable = false)
+  private boolean isWeightUnknown = false;
 
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+  /**
+   * 동물등록번호. 숫자만, 최대 15자리. 선택 입력.
+   */
+  @Column(length = 15)
+  private String registrationNumber;
 
-    /** 수정 일시. JPA Auditing 자동 갱신 */
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
+  /**
+   * 알레르기 여부. 기획서 step3 알레르기 '있어요/없어요'
+   */
+  private Boolean hasAllergy;
 
-    @Builder
-    public Pet(User user, String name, String species, String breed, LocalDate birthDate,
-               Gender gender, boolean isNeutered, String profileImageUrl, Set<PetDisease> diseases) {
-        this.user = user;
-        this.name = name;
-        this.species = species;
-        this.breed = breed;
-        this.birthDate = birthDate;
-        this.gender = gender;
-        this.isNeutered = isNeutered;
-        this.profileImageUrl = profileImageUrl;
-        if (diseases != null) this.diseases = diseases;
-    }
+  /**
+   * 알레르기 직접 입력 내용. hasAllergy=true일 때만 사용.
+   */
+  @Column(columnDefinition = "TEXT")
+  private String allergyDescription;
 
-    /** 정보 수정. null이 아닌 필드만 반영. updatedAt은 @LastModifiedDate가 자동 갱신 */
-    public void update(String name, String species, String breed, LocalDate birthDate,
-                       Gender gender, Boolean isNeutered, String profileImageUrl) {
-        if (name != null) this.name = name;
-        if (species != null) this.species = species;
-        if (breed != null) this.breed = breed;
-        if (birthDate != null) this.birthDate = birthDate;
-        if (gender != null) this.gender = gender;
-        if (isNeutered != null) this.isNeutered = isNeutered;
-        if (profileImageUrl != null) this.profileImageUrl = profileImageUrl;
-    }
+  @Column(columnDefinition = "TEXT")
+  private String profileImageUrl;
+
+  /**
+   * 질병 목록. 최대 5개. pet_diseases 별도 테이블. ElementCollection은 Pet → 단방향이므로 원칙 준수.
+   */
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(
+      name = "pet_diseases",
+      joinColumns = @JoinColumn(name = "pet_id", foreignKey = @ForeignKey(name = "fk_pet_diseases_pet"))
+  )
+  @Enumerated(EnumType.STRING)
+  @Column(name = "disease", length = 30, nullable = false)
+  private Set<PetDisease> diseases = new HashSet<>();
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+
+  @Builder
+  public Pet(User user, String name, String species, String breed,
+      LocalDate birthDate, boolean isBirthDateUnknown,
+      Gender gender, boolean isNeutered,
+      BigDecimal weight, boolean isWeightUnknown,
+      String registrationNumber,
+      Boolean hasAllergy, String allergyDescription,
+      String profileImageUrl, Set<PetDisease> diseases) {
+    this.user = user;
+    this.name = name;
+    this.species = species;
+    this.breed = breed;
+    this.birthDate = birthDate;
+    this.isBirthDateUnknown = isBirthDateUnknown;
+    this.gender = gender;
+    this.isNeutered = isNeutered;
+    this.weight = weight;
+    this.isWeightUnknown = isWeightUnknown;
+    this.registrationNumber = registrationNumber;
+    this.hasAllergy = hasAllergy;
+    this.allergyDescription = allergyDescription;
+    this.profileImageUrl = profileImageUrl;
+      if (diseases != null) {
+          this.diseases = diseases;
+      }
+  }
+
+  /**
+   * 정보 수정. null이 아닌 필드만 반영
+   */
+  public void update(String name, String species, String breed,
+      LocalDate birthDate, Boolean isBirthDateUnknown,
+      Gender gender, Boolean isNeutered,
+      BigDecimal weight, Boolean isWeightUnknown,
+      String registrationNumber,
+      Boolean hasAllergy, String allergyDescription,
+      String profileImageUrl) {
+      if (name != null) {
+          this.name = name;
+      }
+      if (species != null) {
+          this.species = species;
+      }
+      if (breed != null) {
+          this.breed = breed;
+      }
+      if (birthDate != null) {
+          this.birthDate = birthDate;
+      }
+      if (isBirthDateUnknown != null) {
+          this.isBirthDateUnknown = isBirthDateUnknown;
+      }
+      if (gender != null) {
+          this.gender = gender;
+      }
+      if (isNeutered != null) {
+          this.isNeutered = isNeutered;
+      }
+      if (weight != null) {
+          this.weight = weight;
+      }
+      if (isWeightUnknown != null) {
+          this.isWeightUnknown = isWeightUnknown;
+      }
+      if (registrationNumber != null) {
+          this.registrationNumber = registrationNumber;
+      }
+      if (hasAllergy != null) {
+          this.hasAllergy = hasAllergy;
+      }
+      if (allergyDescription != null) {
+          this.allergyDescription = allergyDescription;
+      }
+      if (profileImageUrl != null) {
+          this.profileImageUrl = profileImageUrl;
+      }
+  }
+
+  /**
+   * 질병 목록 수정
+   */
+  public void updateDiseases(Set<PetDisease> diseases) {
+    this.diseases.clear();
+    if (diseases != null)
+      this.diseases.addAll(diseases);
+  }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/enums/PetDisease.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/enums/PetDisease.java
@@ -1,73 +1,74 @@
 package com.newleaseonlife.SafeDogBe.domain.pet.entity.enums;
 
-import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
-import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-/**
- * 반려동물 질병 유형. 등록 시 질병별 기본 체크리스트 템플릿 자동 생성에 사용.
- * defaultTemplates()로 해당 질병에 맞는 CareTemplate 정보를 반환한다.
+/** 수정_3월18일
+ * 반려동물 질병 유형 (기획서 기준 6종).
+ * 등록 시 질병별 기본 체크리스트 자동 생성에 사용.
+ * defaultCheckItems()로 해당 질병의 기본 체크 항목 문자열 목록을 반환한다.
+ *
+ * ✅ 변경: DIABETES, ALLERGY, SKIN_DISEASE 제거
+ * ✅ 변경: EYE_DISEASE, CUSHING 추가
+ * ✅ 변경: 기본 체크리스트 내용을 기획서 명세 기준으로 전면 교체
+ * ✅ 알레르기는 Pet.hasAllergy + Pet.allergyDescription 필드로 분리
  */
 @Getter
 @RequiredArgsConstructor
 public enum PetDisease {
 
-    DIABETES("당뇨",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "당뇨약 복용", "처방에 따라 인슐린 또는 경구약 복용", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.MEAL,    "식이 관리",   "당뇨 맞춤 식단 급여 (고단백·저탄수화물)", RepeatCycle.DAILY)
-            )),
+  HEART_DISEASE("심장병", List.of(
+      "수면 중 안정 시 호흡수(SRR) 측정 및 기록",
+      "점막(혀/잇몸) 색깔 및 기침 양상 관찰",
+      "날씨 확인 후 산책",
+      "식후 즉시 활동 금지 및 휴식 유도"
+  )),
 
-    HEART_DISEASE("심장병",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "심장약 복용",  "처방에 따라 심장 관련 약 복용", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.HOSPITAL, "심장 정기검진", "수의사 지시에 따른 정기 검진", RepeatCycle.MONTHLY)
-            )),
+  KIDNEY_DISEASE("신장질환", List.of(
+      "피부 탄력(탈수) 테스트",
+      "구강 및 잇몸 상태(악취, 궤양) 관찰",
+      "물그릇 세척 및 신선한 물 교체",
+      "음수 유도(입 가까이 물 대주기)"
+  )),
 
-    ARTHRITIS("관절염",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "관절약/보조제 복용", "처방 또는 보조제 급여", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.WALK,     "짧은 산책",          "과격하지 않은 가벼운 산책 (15~20분)", RepeatCycle.DAILY)
-            )),
+  CANCER("암", List.of(
+      "환부 소독 및 드레싱 교체",
+      "종양 크기 변화 및 새 멍울 촉진",
+      "통증 신호 및 컨디션(식욕 등) 모니터링",
+      "체온 측정 및 미열 확인",
+      "반려동물과 5분 놀이하기"
+  )),
 
-    KIDNEY_DISEASE("신장병",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "신장약 복용",  "처방에 따라 신장 관련 약 복용", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.MEAL,     "신장 식이 관리", "저단백·저인 맞춤 식단 급여", RepeatCycle.DAILY)
-            )),
+  EYE_DISEASE("안과질환", List.of(
+      "안구 세정 및 눈 주변 분비물 닦기",
+      "인공눈물 점안",
+      "안구 통증, 충혈, 혼탁도 관찰",
+      "점안 후 눈 비비지 않도록 제지"
+  )),
 
-    ALLERGY("알레르기",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "항히스타민/처방약 복용", "수의사 처방 약 복용", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.BATH,     "정기 목욕·피부 관리",   "알레르겐 제거를 위한 주기적 목욕", RepeatCycle.WEEKLY)
-            )),
+  CUSHING("쿠싱 증후군", List.of(
+      "복부 팽만(올챙이 배) 상태 확인",
+      "피부 발진, 각질 및 피부 얇아짐 관찰",
+      "음수량 및 배뇨 횟수 관찰",
+      "근육 감소 및 보행 상태 확인",
+      "피부 접히는 부위 청결 관리 및 보습제 도포"
+  )),
 
-    SKIN_DISEASE("피부병",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "피부약/연고 도포",  "처방에 따라 피부약·연고 적용", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.BATH,     "약용 샴푸 목욕",    "수의사 권장 약용 샴푸로 목욕", RepeatCycle.WEEKLY)
-            )),
+  ARTHRITIS("관절염", List.of(
+      "기상 직후 보행 및 절뚝임 상태 관찰",
+      "아픈 관절 부위 온찜질 및 마사지 수행",
+      "수동 관절 운동(PROM) 수행",
+      "발바닥 털 정리 및 미끄럼 방지 점검"
+  ));
 
-    CANCER("암",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "항암/처방약 복용",  "처방에 따라 항암제·보조약 복용", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.HOSPITAL, "항암 정기 방문",    "치료 계획에 따른 병원 방문", RepeatCycle.MONTHLY)
-            ));
+  /** 사용자 노출용 한국어 표시명 */
+  private final String description;
 
-    /** 사용자 노출용 한국어 표시명 */
-    private final String description;
-
-    /** 해당 질병에 맞는 기본 케어 템플릿 목록 */
-    private final List<DefaultTemplate> defaultTemplates;
-
-    /**
-     * 자동 생성 CareTemplate 정보를 담는 값 객체.
-     * Pet 등록 시 이 정보를 기반으로 CareTemplate 엔티티를 생성한다.
-     */
-    public record DefaultTemplate(CareType careType, String title, String content, RepeatCycle repeatCycle) {
-    }
+  /**
+   * 해당 질병의 기본 케어 체크리스트 항목 문자열 목록.
+   * Pet 등록 시 이 목록을 기반으로 CareTemplate 엔티티를 생성한다.
+   */
+  private final List<String> defaultCheckItems;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/service/PetService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/service/PetService.java
@@ -1,7 +1,10 @@
+// domain/pet/service/PetService.java
 package com.newleaseonlife.SafeDogBe.domain.pet.service;
 
 import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplate;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
 import com.newleaseonlife.SafeDogBe.domain.care.repository.CareTemplateRepository;
+import com.newleaseonlife.SafeDogBe.domain.pet.converter.PetConverter;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.GuardianAddRequest;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.PetCreateRequest;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.PetUpdateRequest;
@@ -10,7 +13,6 @@ import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.PetGuardian;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetDisease;
-import com.newleaseonlife.SafeDogBe.domain.pet.converter.PetConverter;
 import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetGuardianRepository;
 import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetRepository;
 import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
@@ -21,7 +23,6 @@ import com.newleaseonlife.SafeDogBe.global.error.domain.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,9 +30,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-/**
- * 반려동물(Pet) 도메인 서비스. CRUD, 보호자(Guardian) 추가·삭제·목록 조회.
- * 반려동물 소유자(pet.user)만 수정·삭제·보호자 관리 가능.
+/** 3월 18일 수정
+ * ✅ 수정: create() — 신규 필드(weight, registrationNumber 등) 반영
+ * ✅ 수정: update() — 신규 필드 반영, diseases 수정 지원
+ * ✅ 수정: createDefaultCareTemplates() — PetDisease.defaultCheckItems() 기반 DISEASE_CARE 템플릿 생성
  */
 @Slf4j
 @Service
@@ -45,148 +47,143 @@ public class PetService {
     private final CareTemplateRepository careTemplateRepository;
     private final PetConverter petConverter;
 
-    /** 내가 소유한 반려동물 목록(최신순) */
     public List<PetResponse> findMyPets(Long userId) {
-        log.debug("[PetService] findMyPets userId={}", userId);
-        List<Pet> pets = petRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
-        return petConverter.toResponseList(pets);
+        return petConverter.toResponseList(
+            petRepository.findAllByUserIdOrderByCreatedAtDesc(userId));
     }
 
-    /** 반려동물 단건 조회. 소유자만 조회 가능(보호자 목록 포함 조회는 getGuardians 사용) */
     public PetResponse findById(Long petId, Long userId) {
-        log.debug("[PetService] findById petId={}, userId={}", petId, userId);
         return petConverter.toResponse(getPetAsOwnerOrThrow(petId, userId));
     }
 
-    /** 반려동물 등록. 요청자를 메인 보호자(pet.user)로 저장. 질병 입력 시 질병별 CareTemplate 자동 생성 */
     @Transactional
-    public PetResponse create(Long userId, PetCreateRequest request) {
-        log.info("[PetService] create userId={}, name={}", userId, request.getName());
+    public PetResponse create(Long userId, PetCreateRequest req) {
+        log.info("[PetService] create userId={}, name={}", userId, req.getName());
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        boolean isNeutered = request.getIsNeutered() != null && request.getIsNeutered();
-        Set<PetDisease> diseases = request.getDiseases() != null ? request.getDiseases() : Set.of();
+        Set<PetDisease> diseases = req.getDiseases() != null ? req.getDiseases() : Set.of();
+
         Pet pet = Pet.builder()
-                .user(user)
-                .name(request.getName())
-                .species(request.getSpecies())
-                .breed(request.getBreed())
-                .birthDate(request.getBirthDate())
-                .gender(request.getGender())
-                .isNeutered(isNeutered)
-                .profileImageUrl(request.getProfileImageUrl())
-                .diseases(diseases)
-                .build();
+            .user(user)
+            .name(req.getName())
+            .species(req.getSpecies())
+            .breed(req.getBreed())
+            .birthDate(req.getBirthDate())
+            .isBirthDateUnknown(req.isBirthDateUnknown())
+            .gender(req.getGender())
+            .isNeutered(req.getIsNeutered() != null && req.getIsNeutered())
+            .weight(req.getWeight())
+            .isWeightUnknown(req.isWeightUnknown())
+            .registrationNumber(req.getRegistrationNumber())
+            .hasAllergy(req.getHasAllergy())
+            .allergyDescription(req.getAllergyDescription())
+            .profileImageUrl(req.getProfileImageUrl())
+            .diseases(diseases)
+            .build();
         petRepository.save(pet);
 
-        // 질병 유형별 기본 케어 템플릿 자동 생성
+        // 질병별 기본 DISEASE_CARE 케어 템플릿 자동 생성
         if (!diseases.isEmpty()) {
             createDefaultCareTemplates(pet, diseases);
         }
 
-        log.info("[PetService] create 완료 petId={}, diseases={}", pet.getId(), diseases);
+        log.info("[PetService] create 완료 petId={}", pet.getId());
         return petConverter.toResponse(pet);
     }
 
-    /** 질병 목록을 기반으로 PetDisease에 정의된 기본 CareTemplate 일괄 생성 */
+    @Transactional
+    public PetResponse update(Long petId, Long userId, PetUpdateRequest req) {
+        log.info("[PetService] update petId={}, userId={}", petId, userId);
+        Pet pet = getPetAsOwnerOrThrow(petId, userId);
+
+        pet.update(
+            req.getName(), req.getSpecies(), req.getBreed(),
+            req.getBirthDate(), req.getIsBirthDateUnknown(),
+            req.getGender(), req.getIsNeutered(),
+            req.getWeight(), req.getIsWeightUnknown(),
+            req.getRegistrationNumber(),
+            req.getHasAllergy(), req.getAllergyDescription(),
+            req.getProfileImageUrl()
+        );
+
+        // 질병 목록 수정 시 업데이트
+        if (req.getDiseases() != null) {
+            pet.updateDiseases(req.getDiseases());
+        }
+
+        return petConverter.toResponse(pet);
+    }
+
+    @Transactional
+    public void delete(Long petId, Long userId) {
+        petRepository.delete(getPetAsOwnerOrThrow(petId, userId));
+    }
+
+    public List<PetGuardianResponse> getGuardians(Long petId, Long userId) {
+        Pet pet = getPetAsOwnerOrThrow(petId, userId);
+        return petConverter.toGuardianResponseList(
+            petGuardianRepository.findByPetIdOrderByIdAsc(pet.getId()));
+    }
+
+    @Transactional
+    public PetGuardianResponse addGuardian(Long petId, Long ownerUserId, GuardianAddRequest req) {
+        Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
+        User targetUser = userRepository.findById(req.getUserId())
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        if (petGuardianRepository.existsByPetIdAndUserId(pet.getId(), req.getUserId())) {
+            throw new BusinessException(PetErrorCode.PET_GUARDIAN_ALREADY_EXISTS);
+        }
+
+        PetGuardian guardian = PetGuardian.builder()
+            .user(targetUser).pet(pet).role(req.getRole()).build();
+        return petConverter.toGuardianResponse(petGuardianRepository.save(guardian));
+    }
+
+    /** 보호자 제거. 소유자만 가능 */
+    @Transactional
+    public void removeGuardian(Long petId, Long ownerUserId, Long guardianUserId) {
+        log.info("[PetService] removeGuardian petId={}, ownerUserId={}, guardianUserId={}",
+            petId, ownerUserId, guardianUserId);
+        Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
+        PetGuardian guardian = petGuardianRepository.findByPetIdAndUserId(pet.getId(), guardianUserId)
+            .orElseThrow(() -> new BusinessException(PetErrorCode.PET_GUARDIAN_NOT_FOUND));
+
+        // ✅ [수정] Repository에서 직접 삭제
+        petGuardianRepository.delete(guardian);
+        log.info("[PetService] removeGuardian 완료 guardianId={}", guardian.getId());
+    }
+
+    /**
+     * 질병별 기본 DISEASE_CARE 케어 템플릿 생성.
+     *
+     * ✅ 변경: 기존 MEDICINE/HOSPITAL 타입 → DISEASE_CARE 타입
+     * ✅ 변경: defaultTemplates() → defaultCheckItems() 기반으로 각 체크 항목을 개별 CareTemplate으로 생성
+     */
     private void createDefaultCareTemplates(Pet pet, Set<PetDisease> diseases) {
         List<CareTemplate> templates = new ArrayList<>();
         for (PetDisease disease : diseases) {
-            for (PetDisease.DefaultTemplate tmpl : disease.getDefaultTemplates()) {
+            for (String checkItem : disease.getDefaultCheckItems()) {
                 templates.add(CareTemplate.builder()
-                        .pet(pet)
-                        .careType(tmpl.careType())
-                        .title("[" + disease.getDescription() + "] " + tmpl.title())
-                        .content(tmpl.content())
-                        .repeatCycle(tmpl.repeatCycle())
-                        .build());
+                    .pet(pet)
+                    .careType(CareType.DISEASE_CARE)
+                    .title("[" + disease.getDescription() + "] " + checkItem)
+                    // 주기 미설정 → 매일 생성
+                    .build());
             }
         }
         careTemplateRepository.saveAll(templates);
         log.info("[PetService] 질병 기반 CareTemplate {}개 자동 생성 petId={}", templates.size(), pet.getId());
     }
 
-    /** 반려동물 정보 수정. 소유자만 가능 */
-    @Transactional
-    public PetResponse update(Long petId, Long userId, PetUpdateRequest request) {
-        log.info("[PetService] update petId={}, userId={}", petId, userId);
-        Pet pet = getPetAsOwnerOrThrow(petId, userId);
-        pet.update(
-                request.getName(),
-                request.getSpecies(),
-                request.getBreed(),
-                request.getBirthDate(),
-                request.getGender(),
-                request.getIsNeutered(),
-                request.getProfileImageUrl()
-        );
-        log.info("[PetService] update 완료 petId={}", petId);
-        return petConverter.toResponse(pet);
-    }
-
-    /** 반려동물 삭제. 소유자만 가능. pet_guardian 행은 cascade로 함께 삭제 */
-    @Transactional
-    public void delete(Long petId, Long userId) {
-        log.info("[PetService] delete petId={}, userId={}", petId, userId);
-        Pet pet = getPetAsOwnerOrThrow(petId, userId);
-        petRepository.delete(pet);
-        log.info("[PetService] delete 완료 petId={}", petId);
-    }
-
-    /** 해당 반려동물의 보호자 목록 조회. 소유자만 호출 가능 */
-    public List<PetGuardianResponse> getGuardians(Long petId, Long userId) {
-        log.debug("[PetService] getGuardians petId={}, userId={}", petId, userId);
-        Pet pet = getPetAsOwnerOrThrow(petId, userId);
-        List<PetGuardian> guardians = petGuardianRepository.findByPetIdOrderByIdAsc(pet.getId());
-        return petConverter.toGuardianResponseList(guardians);
-    }
-
-    /** 보호자 추가. 소유자만 가능. 이미 등록된 사용자면 PET_GUARDIAN_ALREADY_EXISTS */
-    @Transactional
-    public PetGuardianResponse addGuardian(Long petId, Long ownerUserId, GuardianAddRequest request) {
-        log.info("[PetService] addGuardian petId={}, ownerUserId={}, targetUserId={}, role={}",
-                petId, ownerUserId, request.getUserId(), request.getRole());
-        Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
-        User targetUser = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-        if (petGuardianRepository.existsByPetIdAndUserId(pet.getId(), request.getUserId())) {
-            log.warn("[PetService] addGuardian 실패 - 이미 보호자로 등록됨 petId={}, userId={}", petId, request.getUserId());
-            throw new BusinessException(PetErrorCode.PET_GUARDIAN_ALREADY_EXISTS);
-        }
-        PetGuardian guardian = PetGuardian.builder()
-                .user(targetUser)
-                .pet(pet)
-                .role(request.getRole())
-                .build();
-        // pet.getGuardians().add()와 repository.save() 동시 호출 시 중복 INSERT 가능 → save()만 사용
-        PetGuardian saved = petGuardianRepository.save(guardian);
-        log.info("[PetService] addGuardian 완료 guardianId={}", saved.getId());
-        return petConverter.toGuardianResponse(saved);
-    }
-
-    /** 보호자 제거. 소유자만 가능. 지정한 userId의 보호자 연결만 삭제 */
-    @Transactional
-    public void removeGuardian(Long petId, Long ownerUserId, Long guardianUserId) {
-        log.info("[PetService] removeGuardian petId={}, ownerUserId={}, guardianUserId={}", petId, ownerUserId, guardianUserId);
-        Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
-        PetGuardian guardian = petGuardianRepository.findByPetIdAndUserId(pet.getId(), guardianUserId)
-                .orElseThrow(() -> {
-                    log.warn("[PetService] removeGuardian 실패 - 보호자 없음 petId={}, userId={}", petId, guardianUserId);
-                    return new BusinessException(PetErrorCode.PET_GUARDIAN_NOT_FOUND);
-                });
-        pet.getGuardians().remove(guardian);
-        log.info("[PetService] removeGuardian 완료 guardianId={} (orphanRemoval)", guardian.getId());
-    }
-
-    /** 반려동물 조회(소유자만). 없거나 권한 없으면 예외 */
     private Pet getPetAsOwnerOrThrow(Long petId, Long userId) {
         return petRepository.findByIdAndUserId(petId, userId)
-                .orElseThrow(() -> {
-                    if (petRepository.findById(petId).isEmpty()) {
-                        return new BusinessException(PetErrorCode.PET_NOT_FOUND);
-                    }
-                    return new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
-                });
+            .orElseThrow(() -> {
+                if (petRepository.findById(petId).isEmpty()) {
+                    return new BusinessException(PetErrorCode.PET_NOT_FOUND);
+                }
+                return new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
+            });
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#75 75

## 📌 작업 내용

- Pet 엔티티 신규 필드 추가
  - `weight` / `isWeightUnknown` (체중 & 모름 체크)
  - `registrationNumber` (동물등록번호 15자리)
  - `isBirthDateUnknown` (출생일 모름 체크)
  - `hasAllergy` / `allergyDescription` (알레르기)
- `PetDisease` enum 기획서 6종으로 교체, 알레르기 분리
- **단방향 전환**: `Pet.guardians` 양방향 필드 제거
  - `pet.getGuardians().remove()` → `Repository.deleteByPetIdAndUserId()`

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
