### PR TITLE
반려동물/반려노트/체크리스트 기획서 반영 및 단방향 리팩토링

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/CareTemplateController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/CareTemplateController.java
@@ -1,8 +1,11 @@
 package com.newleaseonlife.SafeDogBe.domain.care.controller;
 
 import com.newleaseonlife.SafeDogBe.domain.care.dto.request.CareTemplateCreateRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.CareTemplateUpdateRequest;
 import com.newleaseonlife.SafeDogBe.domain.care.dto.response.CareTemplateResponse;
 import com.newleaseonlife.SafeDogBe.domain.care.service.CareTemplateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +13,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
+/** 3월 18일 수정
+ * ✅ 추가: GET /api/care-templates?petId={petId} — 반려동물별 템플릿 목록 조회
+ * ✅ 추가: PUT /api/care-templates/{templateId} — 템플릿 수정
+ * ✅ 변경: RepeatCycle → 새 주기 방식 반영
+ */
+@Tag(name = "CareTemplate", description = "반려노트 케어 템플릿(설정) API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/care-templates")
@@ -17,12 +28,29 @@ public class CareTemplateController {
 
   private final CareTemplateService careTemplateService;
 
-  @PostMapping
-  public ResponseEntity<CareTemplateResponse> createTemplate(@Valid @RequestBody CareTemplateCreateRequest request) {
-    CareTemplateResponse response = careTemplateService.createTemplate(request);
-    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  @Operation(summary = "반려동물 케어 템플릿 목록 조회")
+  @GetMapping
+  public ResponseEntity<List<CareTemplateResponse>> getTemplates(@RequestParam Long petId) {
+    return ResponseEntity.ok(careTemplateService.getTemplatesByPet(petId));
   }
 
+  @Operation(summary = "케어 템플릿 등록")
+  @PostMapping
+  public ResponseEntity<CareTemplateResponse> createTemplate(
+      @Valid @RequestBody CareTemplateCreateRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(careTemplateService.createTemplate(request));
+  }
+
+  @Operation(summary = "케어 템플릿 수정")
+  @PutMapping("/{templateId}")
+  public ResponseEntity<CareTemplateResponse> updateTemplate(
+      @PathVariable Long templateId,
+      @Valid @RequestBody CareTemplateUpdateRequest request) {
+    return ResponseEntity.ok(careTemplateService.updateTemplate(templateId, request));
+  }
+
+  @Operation(summary = "케어 템플릿 비활성화 (Soft Delete)")
   @DeleteMapping("/{templateId}")
   public ResponseEntity<Void> deactivateTemplate(@PathVariable Long templateId) {
     careTemplateService.deactivateTemplate(templateId);

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/DailyChecklistController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/DailyChecklistController.java
@@ -1,12 +1,26 @@
+// domain/care/controller/DailyChecklistController.java
 package com.newleaseonlife.SafeDogBe.domain.care.controller;
 
 import com.newleaseonlife.SafeDogBe.domain.care.dto.response.DailyChecklistResponse;
 import com.newleaseonlife.SafeDogBe.domain.care.service.DailyChecklistService;
+import com.newleaseonlife.SafeDogBe.global.security.CustomPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
+import java.util.List;
+
+/** 3월 18일 수정
+ * ✅ 변경: userId @RequestParam → @AuthenticationPrincipal (보안 적용)
+ * ✅ 추가: GET /api/checklists?petId={}&date={} — 날짜별 체크리스트 조회
+ */
+@Tag(name = "DailyChecklist", description = "일일 체크리스트 조회·완료·취소 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/checklists")
@@ -14,21 +28,29 @@ public class DailyChecklistController {
 
   private final DailyChecklistService dailyChecklistService;
 
-  // TODO: userId는 추후 Spring Security의 @AuthenticationPrincipal 등으로 대체 예정
+  @Operation(summary = "날짜별 반려동물 체크리스트 조회")
+  @GetMapping
+  public ResponseEntity<List<DailyChecklistResponse>> getChecklists(
+      @RequestParam Long petId,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+    return ResponseEntity.ok(dailyChecklistService.getChecklistsByDate(petId, date));
+  }
 
+  @Operation(summary = "체크리스트 완료 처리")
   @PostMapping("/{checklistId}/complete")
   public ResponseEntity<DailyChecklistResponse> completeChecklist(
       @PathVariable Long checklistId,
-      @RequestParam Long userId) {
-    DailyChecklistResponse response = dailyChecklistService.completeChecklist(checklistId, userId);
-    return ResponseEntity.ok(response);
+      @AuthenticationPrincipal CustomPrincipal principal) {
+    return ResponseEntity.ok(
+        dailyChecklistService.completeChecklist(checklistId, principal.getUser().getId()));
   }
 
+  @Operation(summary = "체크리스트 완료 취소")
   @PostMapping("/{checklistId}/uncomplete")
   public ResponseEntity<DailyChecklistResponse> uncompleteChecklist(
       @PathVariable Long checklistId,
-      @RequestParam Long userId) {
-    DailyChecklistResponse response = dailyChecklistService.uncompleteChecklist(checklistId, userId);
-    return ResponseEntity.ok(response);
+      @AuthenticationPrincipal CustomPrincipal principal) {
+    return ResponseEntity.ok(
+        dailyChecklistService.uncompleteChecklist(checklistId, principal.getUser().getId()));
   }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/CareTemplateConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/CareTemplateConverter.java
@@ -1,51 +1,126 @@
 package com.newleaseonlife.SafeDogBe.domain.care.converter;
 
 import com.newleaseonlife.SafeDogBe.domain.care.dto.request.CareTemplateCreateRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.CareTemplateItemRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.CareTemplateItemResponse;
 import com.newleaseonlife.SafeDogBe.domain.care.dto.response.CareTemplateResponse;
 import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplate;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplateItem;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 3월 18일 수정 ✅ 변경: RepeatCycle → repeatCycleValue + repeatCycleUnit + repeatStartDate ✅ 추가:
+ * timeSlot, items, 배변/체중 필드 매핑
+ */
 @Component
 public class CareTemplateConverter {
 
-  // 1. Entity -> Response DTO 변환
-  public CareTemplateResponse toResponse(CareTemplate careTemplate) {
-    if (careTemplate == null) {
+  /**
+   * ✅ 수정: items를 파라미터로 받는 오버로드 추가. CareTemplate.items 필드 제거로 인해 t.getItems() 호출 불가.
+   */
+  public CareTemplateResponse toResponse(CareTemplate t, List<CareTemplateItem> items) {
+    if (t == null) {
       return null;
     }
-
     return CareTemplateResponse.builder()
-        .id(careTemplate.getId())
-        .petId(careTemplate.getPet().getId())
-        .careType(careTemplate.getCareType())
-        .careTypeDescription(careTemplate.getCareType().getDescription())
-        .title(careTemplate.getTitle())
-        .content(careTemplate.getContent())
-        .repeatCycle(careTemplate.getRepeatCycle())
-        .repeatCycleDescription(careTemplate.getRepeatCycle().getDescription())
-        .isActive(careTemplate.isActive())
+        .id(t.getId())
+        .petId(t.getPet().getId())
+        .careType(t.getCareType())
+        .careTypeDescription(t.getCareType().getDescription())
+        .title(t.getTitle())
+        .timeSlot(t.getTimeSlot())
+        .timeSlotDescription(t.getTimeSlot() != null ? t.getTimeSlot().getDescription() : null)
+        .customTimeSlot(t.getCustomTimeSlot())
+        .repeatCycleValue(t.getRepeatCycleValue())
+        .repeatCycleUnit(t.getRepeatCycleUnit())
+        .repeatCycleUnitDescription(
+            t.getRepeatCycleUnit() != null ? t.getRepeatCycleUnit().getDescription() : null)
+        .repeatStartDate(t.getRepeatStartDate())
+        .urineTrackingOn(t.isUrineTrackingOn())
+        .fecesTrackingOn(t.isFecesTrackingOn())
+        .weightRequestOn(t.isWeightRequestOn())
+        .memo(t.getMemo())
+        .isActive(t.isActive())
+        .items(toItemResponseList(items))   // ← items 파라미터로 주입
         .build();
   }
 
-  // 2. Entity List -> Response DTO List 변환 (this 키워드로 내부 인스턴스 메서드 호출)
-  public List<CareTemplateResponse> toResponseList(List<CareTemplate> templates) {
-    return templates.stream()
-        .map(this::toResponse)
-        .collect(Collectors.toList());
+  /**
+   * items 없이 호출 시 빈 목록으로 처리 (단순 조회용)
+   */
+  public CareTemplateResponse toResponse(CareTemplate t) {
+    return toResponse(t, Collections.emptyList());
   }
 
-  // 3. Request DTO + 연관 Entity -> Entity 변환
-  public CareTemplate toEntity(CareTemplateCreateRequest request, Pet pet) {
+  public List<CareTemplateResponse> toResponseList(List<CareTemplate> templates,
+      Map<Long, List<CareTemplateItem>> itemsMap) {
+    return templates.stream()
+        .map(t -> toResponse(t, itemsMap.getOrDefault(t.getId(), Collections.emptyList())))
+        .toList();
+  }
+
+  public CareTemplate toEntity(CareTemplateCreateRequest req, Pet pet) {
     return CareTemplate.builder()
         .pet(pet)
-        .careType(request.getCareType())
-        .title(request.getTitle())
-        .content(request.getContent())
-        .repeatCycle(request.getRepeatCycle())
-        // isActive는 Entity의 기본값(true) 또는 빌더 내에서 처리됨
+        .careType(req.getCareType())
+        .title(req.getTitle())
+        .timeSlot(req.getTimeSlot())
+        .customTimeSlot(req.getCustomTimeSlot())
+        .repeatCycleValue(req.getRepeatCycleValue())
+        .repeatCycleUnit(req.getRepeatCycleUnit())
+        .repeatStartDate(req.getRepeatStartDate())
+        .urineTrackingOn(req.isUrineTrackingOn())
+        .fecesTrackingOn(req.isFecesTrackingOn())
+        .weightRequestOn(req.isWeightRequestOn())
+        .memo(req.getMemo())
         .build();
+  }
+
+  public CareTemplateItem toItemEntity(CareTemplateItemRequest req, CareTemplate template) {
+    return CareTemplateItem.builder()
+        .careTemplate(template)
+        .itemName(req.getItemName())
+        .foodType(req.getFoodType())
+        .groomingType(req.getGroomingType())
+        .customGroomingType(req.getCustomGroomingType())
+        .preventionType(req.getPreventionType())
+        .customPreventionType(req.getCustomPreventionType())
+        .amount(req.getAmount())
+        .amountUnit(req.getAmountUnit())
+        .imageUrl(req.getImageUrl())
+        .note(req.getNote())
+        .sortOrder(req.getSortOrder())
+        .build();
+  }
+
+  private CareTemplateItemResponse toItemResponse(CareTemplateItem item) {
+    return CareTemplateItemResponse.builder()
+        .id(item.getId())
+        .itemName(item.getItemName())
+        .foodType(item.getFoodType())
+        .foodTypeDescription(
+            item.getFoodType() != null ? item.getFoodType().getDescription() : null)
+        .groomingType(item.getGroomingType())
+        .customGroomingType(item.getCustomGroomingType())
+        .preventionType(item.getPreventionType())
+        .customPreventionType(item.getCustomPreventionType())
+        .amount(item.getAmount())
+        .amountUnit(item.getAmountUnit())
+        .imageUrl(item.getImageUrl())
+        .note(item.getNote())
+        .sortOrder(item.getSortOrder())
+        .build();
+  }
+
+  private List<CareTemplateItemResponse> toItemResponseList(List<CareTemplateItem> items) {
+    if (items == null || items.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return items.stream().map(this::toItemResponse).toList();
   }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/DailyChecklistConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/DailyChecklistConverter.java
@@ -1,62 +1,43 @@
 package com.newleaseonlife.SafeDogBe.domain.care.converter;
 
-import com.newleaseonlife.SafeDogBe.domain.care.dto.request.DailyChecklistCreateRequest;
 import com.newleaseonlife.SafeDogBe.domain.care.dto.response.DailyChecklistResponse;
 import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyChecklist;
-import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+import org.springframework.stereotype.Component;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.stereotype.Component;
 
+/** 3월 18일 수정
+ * ✅ 추가: completedByProfileImageUrl 매핑
+ * ✅ 추가: updatedAt 매핑
+ */
 @Component
 public class DailyChecklistConverter {
 
-  // 1. Entity -> Response DTO 변환
-  public DailyChecklistResponse toResponse(DailyChecklist checklist) {
-    return Optional.ofNullable(checklist)
-        .map(cl -> DailyChecklistResponse.builder()
-            .id(cl.getId())
-            .petId(cl.getPet().getId())
-            // 템플릿이 없는 1회성 체크리스트 방어 로직
-            .careTemplateId(cl.getCareTemplate() != null ? cl.getCareTemplate().getId() : null)
-            .targetDate(cl.getTargetDate())
-            .careType(cl.getCareType())
-            .careTypeDescription(cl.getCareType().getDescription())
-            .title(cl.getTitle())
-            .content(cl.getContent())
-            .isCompleted(cl.isCompleted())
-            // 완료자가 아직 없는 경우를 방어하는 Null-Safe 로직
-            .completedByUserId(cl.getCompletedBy() != null ? cl.getCompletedBy().getId() : null)
-            .completedByNickname(cl.getCompletedBy() != null ? cl.getCompletedBy().getNickname() : null)
-            .version(cl.getVersion())
+  public DailyChecklistResponse toResponse(DailyChecklist cl) {
+    return Optional.ofNullable(cl)
+        .map(c -> DailyChecklistResponse.builder()
+            .id(c.getId())
+            .petId(c.getPet().getId())
+            .careTemplateId(c.getCareTemplate() != null ? c.getCareTemplate().getId() : null)
+            .targetDate(c.getTargetDate())
+            .careType(c.getCareType())
+            .careTypeDescription(c.getCareType().getDescription())
+            .title(c.getTitle())
+            .content(c.getContent())
+            .isCompleted(c.isCompleted())
+            .completedByUserId(c.getCompletedBy() != null ? c.getCompletedBy().getId() : null)
+            .completedByNickname(c.getCompletedBy() != null ? c.getCompletedBy().getNickname() : null)
+            .completedByProfileImageUrl(c.getCompletedBy() != null ? c.getCompletedBy().getProfileImageUrl() : null)
+            .version(c.getVersion())
+            .updatedAt(c.getUpdatedAt())
             .build())
         .orElse(null);
   }
 
-  // 2. Entity List -> Response DTO List 변환
-  public List<DailyChecklistResponse> toResponseList(List<DailyChecklist> checklists) {
-    if (checklists == null || checklists.isEmpty()) {
-      return Collections.emptyList();
-    }
-
-    return checklists.stream()
-        .map(this::toResponse)
-        .toList();
-  }
-
-  // 3. Request DTO + 연관 Entity -> Entity 변환 (수동 1회성 할 일 생성용)
-  // 템플릿 없이 수동으로 추가하는 경우이므로 careTemplate 파라미터는 생략합니다.
-  public DailyChecklist toEntity(DailyChecklistCreateRequest request, Pet targetPet) {
-    return DailyChecklist.builder()
-        .pet(targetPet)
-        .targetDate(request.getTargetDate())
-        .careType(request.getCareType())
-        .title(request.getTitle())
-        .content(request.getContent())
-        // careTemplate = null (빌더 기본 동작)
-        // isCompleted = false (엔티티 기본 동작)
-        .build();
+  public List<DailyChecklistResponse> toResponseList(List<DailyChecklist> list) {
+    if (list == null || list.isEmpty()) return Collections.emptyList();
+    return list.stream().map(this::toResponse).toList();
   }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/CareTemplateCreateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/CareTemplateCreateRequest.java
@@ -1,18 +1,31 @@
+// domain/care/dto/request/CareTemplateCreateRequest.java
 package com.newleaseonlife.SafeDogBe.domain.care.dto.request;
 
 import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
-import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycleUnit;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.TimeSlot;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/** 3월 18일 수정
+ * 케어 템플릿 등록 요청.
+ *
+ * ✅ 변경: RepeatCycle → repeatCycleValue + repeatCycleUnit + repeatStartDate
+ * ✅ 추가: timeSlot, customTimeSlot
+ * ✅ 추가: items (세부 항목 목록)
+ * ✅ 추가: urineTrackingOn, fecesTrackingOn (배변노트)
+ * ✅ 추가: weightRequestOn (체중노트)
+ * ✅ 추가: memo
+ */
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class CareTemplateCreateRequest {
 
   @NotNull(message = "반려동물 ID는 필수입니다.")
@@ -21,11 +34,37 @@ public class CareTemplateCreateRequest {
   @NotNull(message = "케어 타입은 필수입니다.")
   private CareType careType;
 
-  @NotBlank(message = "제목은 필수입니다.")
+  @NotNull(message = "제목은 필수입니다.")
   private String title;
 
-  private String content; // 선택 사항이므로 validation 생략
+  /** 시간대 (식사/영양제/산책/급수/의약복용) */
+  private TimeSlot timeSlot;
 
-  @NotNull(message = "반복 주기는 필수입니다.")
-  private RepeatCycle repeatCycle;
+  /** CUSTOM 선택 시 직접 입력값 */
+  private String customTimeSlot;
+
+  /**
+   * 반복 주기 숫자. null이면 주기 미설정(매일 생성).
+   * 예) 1 + DAY → 매일, 7 + DAY → 7일마다
+   */
+  private Integer repeatCycleValue;
+
+  private RepeatCycleUnit repeatCycleUnit;
+
+  private LocalDate repeatStartDate;
+
+  /** 배변 노트 소변 기록 on/off */
+  private boolean urineTrackingOn = false;
+
+  /** 배변 노트 대변 기록 on/off */
+  private boolean fecesTrackingOn = false;
+
+  /** 체중 노트 주기 요청 on/off */
+  private boolean weightRequestOn = false;
+
+  private String memo;
+
+  /** 식사/간식/영양제/의약복용/예방접종/미용 세부 항목 */
+  @Valid
+  private List<CareTemplateItemRequest> items;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/CareTemplateItemRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/CareTemplateItemRequest.java
@@ -1,0 +1,41 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.request;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.FoodType;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.GroomingType;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.PreventionType;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+/** 3월 18일 수정
+ * 케어 템플릿 세부 항목 요청 DTO */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CareTemplateItemRequest {
+
+  /** 항목명 (사료명/영양제명/복약명 등) */
+  private String itemName;
+
+  /** 사료 종류 (MEAL 타입) */
+  private FoodType foodType;
+
+  /** 미용 종류 (GROOMING 타입) */
+  private GroomingType groomingType;
+
+  /** 미용 직접 입력 */
+  private String customGroomingType;
+
+  /** 예방 종류 (PREVENTION 타입) */
+  private PreventionType preventionType;
+
+  /** 예방 직접 입력 */
+  private String customPreventionType;
+
+  private BigDecimal amount;
+  private String amountUnit;
+  private String imageUrl;
+  private String note;
+  private int sortOrder;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/CareTemplateUpdateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/request/CareTemplateUpdateRequest.java
@@ -1,29 +1,33 @@
 package com.newleaseonlife.SafeDogBe.domain.care.dto.request;
 
 import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
-import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycleUnit;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.TimeSlot;
+import lombok.*;
 
+import java.time.LocalDate;
+import java.util.List;
+
+/** 3월 18일 수정
+ * 케어 템플릿 수정 요청.
+ * ✅ 변경: RepeatCycle → repeatCycleValue + repeatCycleUnit + repeatStartDate
+ */
 @Getter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class CareTemplateUpdateRequest {
-  // 수정 시에는 펫 ID가 변경될 일이 없으므로 제외합니다.
 
-  @NotNull(message = "케어 타입은 필수입니다.")
   private CareType careType;
-
-  @NotBlank(message = "제목은 필수입니다.")
   private String title;
-
-  private String content;
-
-  @NotNull(message = "반복 주기는 필수입니다.")
-  private RepeatCycle repeatCycle;
+  private TimeSlot timeSlot;
+  private String customTimeSlot;
+  private Integer repeatCycleValue;
+  private RepeatCycleUnit repeatCycleUnit;
+  private LocalDate repeatStartDate;
+  private boolean urineTrackingOn;
+  private boolean fecesTrackingOn;
+  private boolean weightRequestOn;
+  private String memo;
+  private List<CareTemplateItemRequest> items;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/CareTemplateItemResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/CareTemplateItemResponse.java
@@ -1,0 +1,31 @@
+package com.newleaseonlife.SafeDogBe.domain.care.dto.response;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.FoodType;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.GroomingType;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.PreventionType;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+/** 3월 18일 수정
+ * 케어 템플릿 세부 항목 응답 DTO */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CareTemplateItemResponse {
+
+  private Long id;
+  private String itemName;
+  private FoodType foodType;
+  private String foodTypeDescription;
+  private GroomingType groomingType;
+  private String customGroomingType;
+  private PreventionType preventionType;
+  private String customPreventionType;
+  private BigDecimal amount;
+  private String amountUnit;
+  private String imageUrl;
+  private String note;
+  private int sortOrder;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/CareTemplateResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/CareTemplateResponse.java
@@ -1,12 +1,18 @@
 package com.newleaseonlife.SafeDogBe.domain.care.dto.response;
 
 import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
-import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycleUnit;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.TimeSlot;
+import lombok.*;
 
+import java.time.LocalDate;
+import java.util.List;
+
+/** 3월 18일 수정
+ * 케어 템플릿 응답 DTO.
+ * ✅ 변경: repeatCycle → repeatCycleValue + repeatCycleUnit + repeatStartDate
+ * ✅ 추가: timeSlot, customTimeSlot, items, urineTrackingOn, fecesTrackingOn, memo
+ */
 @Getter
 @Builder
 @NoArgsConstructor
@@ -15,16 +21,20 @@ public class CareTemplateResponse {
 
   private Long id;
   private Long petId;
-
-  // Enum의 원본 값(서버용)과 프론트엔드 노출용 한글 값을 동시에 내려줍니다.
   private CareType careType;
   private String careTypeDescription;
-
   private String title;
-  private String content;
-
-  private RepeatCycle repeatCycle;
-  private String repeatCycleDescription;
-
+  private TimeSlot timeSlot;
+  private String timeSlotDescription;
+  private String customTimeSlot;
+  private Integer repeatCycleValue;
+  private RepeatCycleUnit repeatCycleUnit;
+  private String repeatCycleUnitDescription;
+  private LocalDate repeatStartDate;
+  private boolean urineTrackingOn;
+  private boolean fecesTrackingOn;
+  private boolean weightRequestOn;
+  private String memo;
   private boolean isActive;
+  private List<CareTemplateItemResponse> items;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/DailyChecklistResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/DailyChecklistResponse.java
@@ -1,13 +1,17 @@
+// domain/care/dto/response/DailyChecklistResponse.java
 package com.newleaseonlife.SafeDogBe.domain.care.dto.response;
 
 import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
+import lombok.*;
 
 import java.time.LocalDate;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
 
+/** 3월 18일 수정
+ * 일일 체크리스트 응답 DTO.
+ * ✅ 추가: completedByProfileImageUrl (기획서 3: 체크 완료 시 보호자 프로필 이미지+닉네임 노출)
+ * ✅ 추가: updatedAt (마지막 수정 시간)
+ */
 @Getter
 @Builder
 @NoArgsConstructor
@@ -16,24 +20,17 @@ public class DailyChecklistResponse {
 
   private Long id;
   private Long petId;
-
-  // 원본 템플릿 정보 (수동으로 생성한 체크리스트면 null일 수 있음)
   private Long careTemplateId;
-
   private LocalDate targetDate;
-
   private CareType careType;
   private String careTypeDescription;
-
   private String title;
   private String content;
-
   private boolean isCompleted;
-
-  // 누가 완료했는지 (아직 완료 안 됐으면 null)
   private Long completedByUserId;
   private String completedByNickname;
-
-  // 클라이언트에서 완료 API 호출 시 함께 넘겨야 할 낙관적 락 버전
+  /** ✅ 추가: 완료자 프로필 이미지 URL */
+  private String completedByProfileImageUrl;
   private Integer version;
+  private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/CareTemplate.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/CareTemplate.java
@@ -1,39 +1,37 @@
 package com.newleaseonlife.SafeDogBe.domain.care.entity;
 
 import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
-import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycleUnit;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.TimeSlot;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import jakarta.persistence.*;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+/**
+ * 수정 3월 18일 케어 템플릿. 반려노트 등록 시 설정한 케어 항목.
+ * <p>
+ * ✅ 제거: RepeatCycle enum → repeatCycleValue + repeatCycleUnit + repeatStartDate ✅ 추가: timeSlot
+ * (아침/점심/저녁/직접입력) ✅ 추가: customTimeSlot (직접입력 시 텍스트값) ✅ 추가: memo (케어 블록 하단 메모) ✅ 추가: urinTrackingOn,
+ * fecesTrackingOn (배변노트 전용) ✅ items: CareTemplateItem과 1:N 관계 (식사/영양제 등 세부 항목)
+ * <p>
+ * ⚠️ 단방향 원칙: - [기존 리팩토링 문서 오류] items(@OneToMany) 필드 추가됐었음 → 제거 - CareTemplateItem → CareTemplate
+ * 단방향 @ManyToOne 유지 - items 조회는 CareTemplateItemRepository.findByCareTemplateId()로 처리 - items 삭제는
+ * CareTemplateItemRepository.deleteByCareTemplateId()로 처리
+ */
 @Entity
 @Table(
     name = "care_template",
     indexes = {
-        // 반려동물별 템플릿 목록 조회가 매우 빈번하므로 인덱스 필수
-        @Index(name = "idx_care_template_pet_id", columnList = "pet_id")
+        @Index(name = "idx_care_template_pet_id", columnList = "pet_id"),
+        @Index(name = "idx_care_template_pet_type", columnList = "pet_id, care_type")
     }
 )
 @Getter
@@ -45,7 +43,6 @@ public class CareTemplate {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  // 반려동물 삭제 시 템플릿도 연쇄 삭제(Cascade)되도록 DB 레벨 제약조건 적용
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "pet_id", nullable = false, foreignKey = @ForeignKey(name = "fk_care_template_pet"))
   private Pet pet;
@@ -57,43 +54,140 @@ public class CareTemplate {
   @Column(nullable = false, length = 200)
   private String title;
 
-  @Column(columnDefinition = "TEXT")
-  private String content;
+  // ─── 시간대 ──────────────────────────────────────────────────
+  @Enumerated(EnumType.STRING)
+  @Column(length = 20)
+  private TimeSlot timeSlot;
+
+  /**
+   * CUSTOM 선택 시 직접 입력값
+   */
+  @Column(length = 50)
+  private String customTimeSlot;
+
+  // ─── 반복 주기 ────────────────────────────────────────────────
+  @Column
+  private Integer repeatCycleValue;
 
   @Enumerated(EnumType.STRING)
-  @Column(length = 50)
-  private RepeatCycle repeatCycle;
+  @Column(length = 10)
+  private RepeatCycleUnit repeatCycleUnit;
 
-  // 논리적 삭제 및 스케줄러 생성 여부를 판단하는 핵심 플래그
+  @Column
+  private LocalDate repeatStartDate;
+
+  // ─── 배변 전용 ────────────────────────────────────────────────
+  @Column(nullable = false)
+  private boolean urineTrackingOn = false;
+
+  @Column(nullable = false)
+  private boolean fecesTrackingOn = false;
+
+  // ─── 체중 전용 ────────────────────────────────────────────────
+  @Column(nullable = false)
+  private boolean weightRequestOn = false;
+
+  // ─── 메모 ──────────────────────────────────────────────────
+  @Column(columnDefinition = "TEXT")
+  private String memo;
+
   @Column(nullable = false)
   private boolean isActive = true;
 
-  // SQL 스키마에 updated_at이 없으므로 생성 시간만 자동 추적
   @CreatedDate
   @Column(nullable = false, updatable = false)
   private LocalDateTime createdAt;
 
+  // ❌ 제거: @OneToMany(mappedBy = "careTemplate") List<CareTemplateItem> items
+  //    이유: CareTemplateItem이 CareTemplate으로 @ManyToOne 단방향을 이미 가짐.
+  //         items 목록은 CareTemplateItemRepository.findByCareTemplateIdOrderBySortOrderAsc()로 조회.
+  //         items 삭제는 CareTemplateItemRepository.deleteByCareTemplateId()로 처리.
+
   @Builder
-  public CareTemplate(Pet pet, CareType careType, String title, String content, RepeatCycle repeatCycle) {
+  public CareTemplate(Pet pet, CareType careType, String title,
+      TimeSlot timeSlot, String customTimeSlot,
+      Integer repeatCycleValue, RepeatCycleUnit repeatCycleUnit,
+      LocalDate repeatStartDate,
+      boolean urineTrackingOn, boolean fecesTrackingOn,
+      boolean weightRequestOn, String memo) {
     this.pet = pet;
     this.careType = careType;
     this.title = title;
-    this.content = content;
-    this.repeatCycle = repeatCycle;
+    this.timeSlot = timeSlot;
+    this.customTimeSlot = customTimeSlot;
+    this.repeatCycleValue = repeatCycleValue;
+    this.repeatCycleUnit = repeatCycleUnit;
+    this.repeatStartDate = repeatStartDate;
+    this.urineTrackingOn = urineTrackingOn;
+    this.fecesTrackingOn = fecesTrackingOn;
+    this.weightRequestOn = weightRequestOn;
+    this.memo = memo;
     this.isActive = true;
   }
 
-  // 비즈니스 로직 1: 템플릿 내용 수정 (제목, 내용, 반복 주기)
-  public void updateTemplate(CareType careType, String title, String content, RepeatCycle repeatCycle) {
-    if (careType != null) this.careType = careType;
-    if (title != null) this.title = title;
-    if (content != null) this.content = content;
-    if (repeatCycle != null) this.repeatCycle = repeatCycle;
+  public void update(CareType careType, String title,
+      TimeSlot timeSlot, String customTimeSlot,
+      Integer repeatCycleValue, RepeatCycleUnit repeatCycleUnit,
+      LocalDate repeatStartDate,
+      boolean urineTrackingOn, boolean fecesTrackingOn,
+      boolean weightRequestOn, String memo) {
+    if (careType != null) {
+      this.careType = careType;
+    }
+    if (title != null) {
+      this.title = title;
+    }
+    this.timeSlot = timeSlot;
+    this.customTimeSlot = customTimeSlot;
+    this.repeatCycleValue = repeatCycleValue;
+    this.repeatCycleUnit = repeatCycleUnit;
+    this.repeatStartDate = repeatStartDate;
+    this.urineTrackingOn = urineTrackingOn;
+    this.fecesTrackingOn = fecesTrackingOn;
+    this.weightRequestOn = weightRequestOn;
+    if (memo != null) {
+      this.memo = memo;
+    }
   }
 
-  // 비즈니스 로직 2: 템플릿 비활성화 (Soft Delete 방식)
-  // 과거의 완료된 체크리스트 기록을 유지하기 위해 물리적 삭제(DELETE) 대신 비활성화 처리
   public void deactivate() {
     this.isActive = false;
+  }
+
+  /**
+   * 스케줄러에서 오늘 생성 여부 판단
+   */
+  public boolean shouldGenerateToday(LocalDate today) {
+    if (!isActive) {
+      return false;
+    }
+    if (repeatCycleValue == null || repeatCycleUnit == null || repeatStartDate == null) {
+      return true; // 주기 미설정 → 매일
+    }
+    if (today.isBefore(repeatStartDate)) {
+      return false;
+    }
+    return switch (repeatCycleUnit) {
+      case DAY -> {
+        long days = today.toEpochDay() - repeatStartDate.toEpochDay();
+        yield days % repeatCycleValue == 0;
+      }
+      case WEEK -> {
+        long daysBetween = today.toEpochDay() - repeatStartDate.toEpochDay();
+        yield daysBetween % (repeatCycleValue * 7L) == 0;
+      }
+      case MONTH -> {
+        int months = (today.getYear() - repeatStartDate.getYear()) * 12
+            + (today.getMonthValue() - repeatStartDate.getMonthValue());
+        yield months >= 0 && months % repeatCycleValue == 0
+            && today.getDayOfMonth() == repeatStartDate.getDayOfMonth();
+      }
+      case YEAR -> {
+        int years = today.getYear() - repeatStartDate.getYear();
+        yield years >= 0 && years % repeatCycleValue == 0
+            && today.getMonthValue() == repeatStartDate.getMonthValue()
+            && today.getDayOfMonth() == repeatStartDate.getDayOfMonth();
+      }
+    };
   }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/CareTemplateItem.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/CareTemplateItem.java
@@ -1,0 +1,119 @@
+package com.newleaseonlife.SafeDogBe.domain.care.entity;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.FoodType;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.GroomingType;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.PreventionType;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/** 수정 3월 18일
+ * 케어 템플릿 세부 항목.
+ * 식사/간식/영양제/의약복용/예방접종/미용 등 CareType별 상세 정보.
+ *
+ * ✅ 신규: 기존 CareTemplate.content(TEXT 1개)로는 복수 항목 표현 불가 → 별도 테이블로 분리
+ */
+@Entity
+@Table(
+    name = "care_template_item",
+    indexes = {
+        @Index(name = "idx_care_item_template_id", columnList = "care_template_id")
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CareTemplateItem {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "care_template_id", nullable = false,
+      foreignKey = @ForeignKey(name = "fk_care_item_template"))
+  private CareTemplate careTemplate;
+
+  /** 항목명 (사료명/간식명/영양제명/복약명/예방약명) */
+  @Column(length = 200)
+  private String itemName;
+
+  // ─── 식사 전용 ─────────────────────────────────────────────────
+  /** 사료 종류 (건식/습식). MEAL 타입에서 사용 */
+  @Enumerated(EnumType.STRING)
+  @Column(length = 10)
+  private FoodType foodType;
+
+  // ─── 미용 전용 ─────────────────────────────────────────────────
+  /** 미용 종류. GROOMING 타입에서 사용 */
+  @Enumerated(EnumType.STRING)
+  @Column(length = 30)
+  private GroomingType groomingType;
+
+  /** 미용 직접입력 시 텍스트 */
+  @Column(length = 100)
+  private String customGroomingType;
+
+  // ─── 예방/접종 전용 ────────────────────────────────────────────
+  /** 예방 종류. PREVENTION 타입에서 사용 */
+  @Enumerated(EnumType.STRING)
+  @Column(length = 30)
+  private PreventionType preventionType;
+
+  /** 예방 직접입력 시 텍스트 */
+  @Column(length = 100)
+  private String customPreventionType;
+
+  // ─── 공통 ─────────────────────────────────────────────────────
+  /** 제공량 (숫자) */
+  @Column(precision = 8, scale = 2)
+  private BigDecimal amount;
+
+  /** 제공량 단위 (g, 컵, 밥그릇, 개, 포, 방울, 봉지 등 직접입력 포함) */
+  @Column(length = 50)
+  private String amountUnit;
+
+  /** 이미지 URL (S3) */
+  @Column(columnDefinition = "TEXT")
+  private String imageUrl;
+
+  /** 특이사항 */
+  @Column(columnDefinition = "TEXT")
+  private String note;
+
+  /** 정렬 순서 */
+  @Column(nullable = false)
+  private int sortOrder = 0;
+
+  @Builder
+  public CareTemplateItem(CareTemplate careTemplate, String itemName,
+      FoodType foodType,
+      GroomingType groomingType, String customGroomingType,
+      PreventionType preventionType, String customPreventionType,
+      BigDecimal amount, String amountUnit,
+      String imageUrl, String note, int sortOrder) {
+    this.careTemplate = careTemplate;
+    this.itemName = itemName;
+    this.foodType = foodType;
+    this.groomingType = groomingType;
+    this.customGroomingType = customGroomingType;
+    this.preventionType = preventionType;
+    this.customPreventionType = customPreventionType;
+    this.amount = amount;
+    this.amountUnit = amountUnit;
+    this.imageUrl = imageUrl;
+    this.note = note;
+    this.sortOrder = sortOrder;
+  }
+
+  public void update(String itemName, BigDecimal amount, String amountUnit,
+      String imageUrl, String note) {
+    if (itemName != null) this.itemName = itemName;
+    if (amount != null) this.amount = amount;
+    if (amountUnit != null) this.amountUnit = amountUnit;
+    if (imageUrl != null) this.imageUrl = imageUrl;
+    if (note != null) this.note = note;
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/CareTemplateItemRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/CareTemplateItemRepository.java
@@ -1,0 +1,26 @@
+package com.newleaseonlife.SafeDogBe.domain.care.repository;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplateItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+/** 3월 18일 수정*/
+public interface CareTemplateItemRepository extends JpaRepository<CareTemplateItem, Long> {
+
+  List<CareTemplateItem> findByCareTemplateIdOrderBySortOrderAsc(Long careTemplateId);
+
+  List<CareTemplateItem> findByCareTemplateIdIn(List<Long> careTemplateIds);
+
+  /**
+   * ✅ 수정: @Modifying 추가 필수.
+   * JPQL 벌크 DELETE는 영속성 컨텍스트를 우회하므로
+   * Service에서 호출 후 EntityManager.flush()+clear() 또는
+   * @Modifying(clearAutomatically = true) 옵션 사용.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM CareTemplateItem c WHERE c.careTemplate.id = :careTemplateId")
+  void deleteByCareTemplateId(Long careTemplateId);
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/CareTemplateRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/CareTemplateRepository.java
@@ -1,20 +1,25 @@
 package com.newleaseonlife.SafeDogBe.domain.care.repository;
 
 import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplate;
-import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
+/** 3월 18일 수정
+ * ✅ 변경: findAllActiveTemplatesByCycleWithPet → findAllActiveTemplatesWithPet
+ *   (RepeatCycle 제거로 쿼리 변경. 주기 계산은 Service에서 shouldGenerateToday()로 처리)
+ */
 public interface CareTemplateRepository extends JpaRepository<CareTemplate, Long> {
 
-  // 1. 특정 반려동물의 "현재 활성화된" 케어 템플릿 목록 조회 (앱 화면 노출용)
-  List<CareTemplate> findByPetIdAndIsActiveTrue(Long petId);
+  /** 특정 반려동물의 활성 템플릿 목록 (items 페치조인) */
+  @Query("SELECT ct FROM CareTemplate ct LEFT JOIN FETCH ct.items WHERE ct.pet.id = :petId AND ct.isActive = true ORDER BY ct.id ASC")
+  List<CareTemplate> findActiveByPetId(Long petId);
 
-  // 2. 매일 자정 스케줄러(Batch) 실행 시, 전체 반려동물의 활성화된 반복 템플릿을 가져오기 위한 쿼리
-  // N+1 방지를 위해 페치 조인 사용
-  @Query("SELECT ct FROM CareTemplate ct JOIN FETCH ct.pet WHERE ct.isActive = true AND ct.repeatCycle = :repeatCycle")
-  List<CareTemplate> findAllActiveTemplatesByCycleWithPet(@Param("repeatCycle") RepeatCycle repeatCycle);
+  /**
+   * 스케줄러용: 전체 활성 템플릿 + pet 페치조인.
+   * ✅ 변경: 기존 RepeatCycle.DAILY 필터 제거 → shouldGenerateToday()로 판단
+   */
+  @Query("SELECT ct FROM CareTemplate ct JOIN FETCH ct.pet WHERE ct.isActive = true")
+  List<CareTemplate> findAllActiveTemplatesWithPet();
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/DailyChecklistRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/DailyChecklistRepository.java
@@ -1,3 +1,4 @@
+// domain/care/repository/DailyChecklistRepository.java
 package com.newleaseonlife.SafeDogBe.domain.care.repository;
 
 import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyChecklist;
@@ -8,12 +9,24 @@ import org.springframework.data.repository.query.Param;
 import java.time.LocalDate;
 import java.util.List;
 
+/** 3월 18일 수정
+ * ✅ 추가: findAllByPetIdAndTargetDateBetween (캘린더 조회용)
+ */
 public interface DailyChecklistRepository extends JpaRepository<DailyChecklist, Long> {
 
-  // 1. 메인 화면: 특정 반려동물의 '오늘(특정 날짜)' 할 일 목록 조회 (N+1 방지 페치 조인)
-  @Query("SELECT d FROM DailyChecklist d LEFT JOIN FETCH d.completedBy WHERE d.pet.id = :petId AND d.targetDate = :targetDate")
-  List<DailyChecklist> findAllByPetIdAndTargetDateWithUser(@Param("petId") Long petId, @Param("targetDate") LocalDate targetDate);
+  /** 메인 화면: 특정 날짜의 반려동물 체크리스트 조회 */
+  @Query("SELECT d FROM DailyChecklist d LEFT JOIN FETCH d.completedBy WHERE d.pet.id = :petId AND d.targetDate = :targetDate ORDER BY d.id ASC")
+  List<DailyChecklist> findAllByPetIdAndTargetDateWithUser(@Param("petId") Long petId,
+      @Param("targetDate") LocalDate targetDate);
 
-  // 2. 스케줄러 방어 로직: 이미 오늘 날짜로 해당 템플릿 기반의 체크리스트가 생성되었는지 확인
+  /** 스케줄러 중복 방지: 오늘 날짜로 해당 템플릿 기반 체크리스트 생성 여부 확인 */
   boolean existsByCareTemplateIdAndTargetDate(Long careTemplateId, LocalDate targetDate);
+
+  /**
+   * 캘린더 조회: 특정 기간 내 기록이 있는 날짜 목록 (내림차순)
+   */
+  @Query("SELECT DISTINCT d.targetDate FROM DailyChecklist d WHERE d.pet.id = :petId AND d.targetDate BETWEEN :from AND :to ORDER BY d.targetDate DESC")
+  List<LocalDate> findDistinctDatesByPetIdAndDateBetween(@Param("petId") Long petId,
+      @Param("from") LocalDate from,
+      @Param("to") LocalDate to);
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/CareSchedulerService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/CareSchedulerService.java
@@ -2,8 +2,8 @@ package com.newleaseonlife.SafeDogBe.domain.care.service;
 
 import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplate;
 import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyChecklist;
-import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
 import com.newleaseonlife.SafeDogBe.domain.care.repository.CareTemplateRepository;
+import com.newleaseonlife.SafeDogBe.domain.care.repository.ChecklistHistoryLogRepository;
 import com.newleaseonlife.SafeDogBe.domain.care.repository.DailyChecklistRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -13,60 +13,74 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
-@Slf4j // 콘솔에 배치 결과를 찍기 위한 로깅 어노테이션
+/** 3월 18일 수정
+ * ✅ 변경: RepeatCycle.DAILY 필터 제거 → CareTemplate.shouldGenerateToday()로 주기 판단
+ * ✅ 추가: 로그 90일 자동 삭제 배치
+ */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CareSchedulerService {
 
   private final CareTemplateRepository careTemplateRepository;
   private final DailyChecklistRepository dailyChecklistRepository;
+  private final ChecklistHistoryLogRepository historyLogRepository;
 
   /**
-   * 매일 자정(KST 00:00:00)에 실행되는 자동 체크리스트 생성 배치
-   * cron = "초 분 시 일 월 요일"
+   * 매일 자정(KST 00:00:00) 일일 체크리스트 자동 생성.
+   *
+   * ✅ 변경: findAllActiveTemplatesByCycleWithPet(DAILY) → findAllActiveTemplatesWithPet()
+   *   각 템플릿의 shouldGenerateToday()로 오늘 생성 여부 판단
    */
   @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
   @Transactional
   public void generateDailyChecklists() {
-    // 1. 기획서 기준대로 시스템 시간이 아닌 철저히 KST(한국 시간) 기준의 오늘 날짜 획득
     LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-    log.info("[Batch Start] {} 일자 반려노트 DailyChecklist 자동 생성 시작", today);
+    log.info("[Batch Start] {} 일자 DailyChecklist 자동 생성 시작", today);
 
-    // 2. '매일(DAILY)' 반복 설정이 되어 있으면서 비활성화되지 않은(isActive=true) 템플릿 목록 싹쓸이 (N+1 방지 적용)
-    List<CareTemplate> dailyTemplates = careTemplateRepository.findAllActiveTemplatesByCycleWithPet(RepeatCycle.DAILY);
+    List<CareTemplate> allTemplates = careTemplateRepository.findAllActiveTemplatesWithPet();
+    List<DailyChecklist> toSave = new ArrayList<>();
 
-    // 저장을 위해 모아둘 리스트 (건바이건 Insert 방지)
-    List<DailyChecklist> checklistsToSave = new ArrayList<>();
+    for (CareTemplate template : allTemplates) {
+      // 오늘 이 템플릿을 생성해야 하는지 주기 판단
+      if (!template.shouldGenerateToday(today)) continue;
 
-    for (CareTemplate template : dailyTemplates) {
-      // 3. 방어 로직: 스케줄러가 모종의 이유로 두 번 돌더라도, 오늘 날짜로 이미 생성된 할 일이 있다면 건너뜀 (중복 생성 방지)
-      boolean isAlreadyGenerated = dailyChecklistRepository.existsByCareTemplateIdAndTargetDate(template.getId(), today);
-
-      if (!isAlreadyGenerated) {
-        // 4. 원본 템플릿의 '현재' 텍스트를 그대로 복사(스냅샷)하여 새로운 엔티티 조립
-        DailyChecklist newChecklist = DailyChecklist.builder()
-            .pet(template.getPet())
-            .careTemplate(template)
-            .targetDate(today)
-            .careType(template.getCareType())
-            .title(template.getTitle())
-            .content(template.getContent())
-            .build();
-
-        checklistsToSave.add(newChecklist);
+      // 중복 생성 방지
+      if (dailyChecklistRepository.existsByCareTemplateIdAndTargetDate(template.getId(), today)) {
+        continue;
       }
+
+      toSave.add(DailyChecklist.builder()
+          .pet(template.getPet())
+          .careTemplate(template)
+          .targetDate(today)
+          .careType(template.getCareType())
+          .title(template.getTitle())
+          .content(template.getMemo())
+          .build());
     }
 
-    // 5. 모아둔 리스트를 한 번의 쿼리(Batch Insert)로 DB에 꽂아 넣음 (성능 최적화)
-    if (!checklistsToSave.isEmpty()) {
-      dailyChecklistRepository.saveAll(checklistsToSave);
-      log.info("[Batch Success] 총 {}개의 DailyChecklist가 성공적으로 자동 생성되었습니다.", checklistsToSave.size());
+    if (!toSave.isEmpty()) {
+      dailyChecklistRepository.saveAll(toSave);
+      log.info("[Batch Success] {}개 DailyChecklist 생성 완료", toSave.size());
     } else {
-      log.info("[Batch End] 오늘 날짜로 새로 생성할 DailyChecklist가 없습니다.");
+      log.info("[Batch End] 생성할 DailyChecklist 없음");
     }
+  }
+
+  /**
+   * 매일 새벽 1시: 90일 초과 로그 삭제 (기획서 3: 로그 90일 보관)
+   */
+  @Scheduled(cron = "0 0 1 * * *", zone = "Asia/Seoul")
+  @Transactional
+  public void deleteOldLogs() {
+    LocalDateTime cutoff = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusDays(90);
+    int deleted = historyLogRepository.deleteOldLogs(cutoff);
+    log.info("[Batch] 90일 초과 체크리스트 로그 {}건 삭제 완료", deleted);
   }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/CareTemplateService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/CareTemplateService.java
@@ -2,48 +2,117 @@ package com.newleaseonlife.SafeDogBe.domain.care.service;
 
 import com.newleaseonlife.SafeDogBe.domain.care.converter.CareTemplateConverter;
 import com.newleaseonlife.SafeDogBe.domain.care.dto.request.CareTemplateCreateRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.CareTemplateItemRequest;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.CareTemplateUpdateRequest;
 import com.newleaseonlife.SafeDogBe.domain.care.dto.response.CareTemplateResponse;
 import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplate;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplateItem;
+import com.newleaseonlife.SafeDogBe.domain.care.repository.CareTemplateItemRepository;
 import com.newleaseonlife.SafeDogBe.domain.care.repository.CareTemplateRepository;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
 import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetRepository;
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.CareErrorCode;
+import com.newleaseonlife.SafeDogBe.global.error.domain.PetErrorCode;
 
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
+import java.util.List;
+
+/** 3월 18일 수정
+ * ✅ 추가: updateTemplate() — 수정 기능
+ * ✅ 추가: getTemplatesByPet() — 조회 기능
+ * ✅ 변경: createTemplate() — 세부 항목(items) 저장 포함
+ */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class CareTemplateService {
 
   private final CareTemplateRepository careTemplateRepository;
+  private final CareTemplateItemRepository careTemplateItemRepository;
   private final PetRepository petRepository;
-  private final CareTemplateConverter careTemplateConverter;
+  private final CareTemplateConverter converter;
 
-  @Transactional
-  public CareTemplateResponse createTemplate(CareTemplateCreateRequest request) {
-    // 1. 반려동물 검증 및 조회
-    Pet pet = petRepository.findById(request.getPetId())
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 반려동물입니다."));
+  /** 반려동물의 활성 케어 템플릿 목록 조회 (items 포함) */
+  public List<CareTemplateResponse> getTemplatesByPet(Long petId) {
+    List<CareTemplate> templates = careTemplateRepository.findActiveByPetId(petId);
+    if (templates.isEmpty()) return Collections.emptyList();
 
-    // 2. Converter를 통해 Entity 조립
-    CareTemplate careTemplate = careTemplateConverter.toEntity(request, pet);
+    // ✅ 수정: CareTemplate.items 필드 제거로 인해 별도 조회 필요
+    List<Long> templateIds = templates.stream().map(CareTemplate::getId).toList();
+    Map<Long, List<CareTemplateItem>> itemsMap =
+        careTemplateItemRepository.findByCareTemplateIdIn(templateIds)
+            .stream()
+            .collect(Collectors.groupingBy(item -> item.getCareTemplate().getId()));
 
-    // 3. 영속화
-    CareTemplate savedTemplate = careTemplateRepository.save(careTemplate);
-
-    // 4. Response DTO로 변환하여 반환
-    return careTemplateConverter.toResponse(savedTemplate);
+    return converter.toResponseList(templates, itemsMap);
   }
 
+  /** 케어 템플릿 등록 (세부 항목 포함) */
+  @Transactional
+  public CareTemplateResponse createTemplate(CareTemplateCreateRequest req) {
+    Pet pet = petRepository.findById(req.getPetId())
+        .orElseThrow(() -> new BusinessException(PetErrorCode.PET_NOT_FOUND));
+
+    CareTemplate template = converter.toEntity(req, pet);
+    careTemplateRepository.save(template);
+
+    List<CareTemplateItem> savedItems = Collections.emptyList();
+    if (req.getItems() != null && !req.getItems().isEmpty()) {
+      List<CareTemplateItem> items = req.getItems().stream()
+          .map(itemReq -> converter.toItemEntity(itemReq, template))
+          .toList();
+      savedItems = careTemplateItemRepository.saveAll(items);
+    }
+
+    log.info("[CareTemplateService] createTemplate 완료 templateId={}", template.getId());
+    return converter.toResponse(template, savedItems);
+  }
+
+  /** 케어 템플릿 수정 (세부 항목 전체 교체) */
+  @Transactional
+  public CareTemplateResponse updateTemplate(Long templateId, CareTemplateUpdateRequest req) {
+    CareTemplate template = getTemplateOrThrow(templateId);
+
+    template.update(
+        req.getCareType(), req.getTitle(),
+        req.getTimeSlot(), req.getCustomTimeSlot(),
+        req.getRepeatCycleValue(), req.getRepeatCycleUnit(), req.getRepeatStartDate(),
+        req.isUrineTrackingOn(), req.isFecesTrackingOn(),
+        req.isWeightRequestOn(), req.getMemo()
+    );
+
+    if (req.getItems() != null) {
+      // ✅ 수정: @Modifying(clearAutomatically = true) 덕분에 삭제 후 캐시 자동 클리어
+      careTemplateItemRepository.deleteByCareTemplateId(templateId);
+
+      List<CareTemplateItem> newItems = req.getItems().stream()
+          .map(itemReq -> converter.toItemEntity(itemReq, template))
+          .toList();
+      careTemplateItemRepository.saveAll(newItems);
+    }
+
+    log.info("[CareTemplateService] updateTemplate 완료 templateId={}", templateId);
+    // ✅ 수정: items 필드가 CareTemplate에 없으므로 converter에서 별도 조회 필요
+    return converter.toResponse(template, careTemplateItemRepository.findByCareTemplateIdOrderBySortOrderAsc(templateId));
+  }
+
+  /** 케어 템플릿 비활성화 (Soft Delete) */
   @Transactional
   public void deactivateTemplate(Long templateId) {
-    // 1. 템플릿 조회
-    CareTemplate template = careTemplateRepository.findById(templateId)
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 템플릿입니다."));
+    getTemplateOrThrow(templateId).deactivate();
+  }
 
-    // 2. 비활성화 (Soft Delete) - 더티 체킹에 의해 자동 UPDATE 쿼리 발생
-    template.deactivate();
+  private CareTemplate getTemplateOrThrow(Long templateId) {
+    return careTemplateRepository.findById(templateId)
+        .orElseThrow(() -> new BusinessException(CareErrorCode.CARE_TEMPLATE_NOT_FOUND));
   }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/DailyChecklistService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/DailyChecklistService.java
@@ -9,11 +9,23 @@ import com.newleaseonlife.SafeDogBe.domain.care.repository.ChecklistHistoryLogRe
 import com.newleaseonlife.SafeDogBe.domain.care.repository.DailyChecklistRepository;
 import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
 import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.CareErrorCode;
+import com.newleaseonlife.SafeDogBe.global.error.domain.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+/** 3월 18일 수정
+ * ✅ 추가: getChecklistsByDate() — 날짜별 체크리스트 조회
+ * ✅ 추가: 당일 여부 검증 (기획서 3: 오늘 날짜만 수정 가능)
+ * ✅ 변경: completeChecklist/uncompleteChecklist — 날짜 검증 추가
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -22,58 +34,79 @@ public class DailyChecklistService {
   private final DailyChecklistRepository dailyChecklistRepository;
   private final ChecklistHistoryLogRepository historyLogRepository;
   private final UserRepository userRepository;
-  private final DailyChecklistConverter checklistConverter;
+  private final DailyChecklistConverter converter;
 
-  @Transactional
-  public DailyChecklistResponse completeChecklist(Long checklistId, Long userId) {
-    // 1. 체크리스트와 유저 조회
-    DailyChecklist checklist = dailyChecklistRepository.findById(checklistId)
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 할 일입니다."));
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
-
-    // 2. 이미 완료된 항목인지 1차 방어 로직 (JPA 낙관적 락이 2차 방어 수행)
-    if (checklist.isCompleted()) {
-      throw new IllegalStateException("이미 완료 처리된 항목입니다.");
-    }
-
-    // 3. 도메인 로직 호출: 완료 상태 및 행위자 업데이트 (더티 체킹 발생)
-    checklist.complete(user);
-
-    // 4. 부수 효과(Side Effect): 히스토리 로그 생성 및 저장
-    ChecklistHistoryLog log = ChecklistHistoryLog.builder()
-        .dailyChecklist(checklist)
-        .user(user)
-        .actionType(ChecklistActionType.CHECK)
-        .build();
-    historyLogRepository.save(log);
-
-    // 5. 프론트엔드로 최신 상태(Version 포함) 반환
-    return checklistConverter.toResponse(checklist);
+  /** 특정 날짜의 반려동물 체크리스트 목록 조회 */
+  public List<DailyChecklistResponse> getChecklistsByDate(Long petId, LocalDate targetDate) {
+    return converter.toResponseList(
+        dailyChecklistRepository.findAllByPetIdAndTargetDateWithUser(petId, targetDate));
   }
 
+  /**
+   * 체크리스트 완료.
+   * ✅ 추가: 오늘 날짜만 수정 가능 검증
+   */
   @Transactional
-  public DailyChecklistResponse uncompleteChecklist(Long checklistId, Long userId) {
-    DailyChecklist checklist = dailyChecklistRepository.findById(checklistId)
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 할 일입니다."));
-    User user = userRepository.findById(userId) // 취소를 누른 사람의 정보
-        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+  public DailyChecklistResponse completeChecklist(Long checklistId, Long userId) {
+    DailyChecklist checklist = getChecklistOrThrow(checklistId);
+    User user = getUserOrThrow(userId);
 
-    if (!checklist.isCompleted()) {
-      throw new IllegalStateException("아직 완료되지 않은 항목입니다.");
+    validateTodayOnly(checklist);
+
+    if (checklist.isCompleted()) {
+      throw new BusinessException(CareErrorCode.CHECKLIST_ALREADY_COMPLETED);
     }
 
-    // 도메인 로직: 상태 초기화
-    checklist.uncomplete();
+    checklist.complete(user);
+    saveLog(checklist, user, ChecklistActionType.CHECK);
+    return converter.toResponse(checklist);
+  }
 
-    // 부수 효과: "취소" 로그 기록 (누가 취소했는지 추적)
-    ChecklistHistoryLog log = ChecklistHistoryLog.builder()
+  /**
+   * 체크리스트 완료 취소.
+   * ✅ 추가: 오늘 날짜만 수정 가능 검증
+   */
+  @Transactional
+  public DailyChecklistResponse uncompleteChecklist(Long checklistId, Long userId) {
+    DailyChecklist checklist = getChecklistOrThrow(checklistId);
+    User user = getUserOrThrow(userId);
+
+    validateTodayOnly(checklist);
+
+    if (!checklist.isCompleted()) {
+      throw new BusinessException(CareErrorCode.CHECKLIST_NOT_COMPLETED);
+    }
+
+    checklist.uncomplete();
+    saveLog(checklist, user, ChecklistActionType.UNCHECK);
+    return converter.toResponse(checklist);
+  }
+
+  /**
+   * 기획서 3: "당일 체크리스트만 수정 가능. 과거 날짜는 읽기 전용"
+   */
+  private void validateTodayOnly(DailyChecklist checklist) {
+    LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+    if (!checklist.getTargetDate().equals(today)) {
+      throw new BusinessException(CareErrorCode.CHECKLIST_DATE_NOT_TODAY);
+    }
+  }
+
+  private void saveLog(DailyChecklist checklist, User user, ChecklistActionType actionType) {
+    historyLogRepository.save(ChecklistHistoryLog.builder()
         .dailyChecklist(checklist)
         .user(user)
-        .actionType(ChecklistActionType.UNCHECK)
-        .build();
-    historyLogRepository.save(log);
+        .actionType(actionType)
+        .build());
+  }
 
-    return checklistConverter.toResponse(checklist);
+  private DailyChecklist getChecklistOrThrow(Long id) {
+    return dailyChecklistRepository.findById(id)
+        .orElseThrow(() -> new BusinessException(CareErrorCode.CHECKLIST_NOT_FOUND));
+  }
+
+  private User getUserOrThrow(Long id) {
+    return userRepository.findById(id)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
   }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/converter/PetConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/converter/PetConverter.java
@@ -1,58 +1,57 @@
+// domain/pet/converter/PetConverter.java
 package com.newleaseonlife.SafeDogBe.domain.pet.converter;
 
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetGuardianResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.PetGuardian;
-
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-/**
- * Pet · PetGuardian 엔티티 → API 응답 DTO 변환.
+/** 3월 18일 수정
+ * ✅ 추가: weight, isWeightUnknown, registrationNumber,
+ *          isBirthDateUnknown, hasAllergy, allergyDescription 매핑
  */
 @Component
 public class PetConverter {
 
-    /** Pet → PetResponse. 보호자 목록은 별도 API로 조회 */
     public PetResponse toResponse(Pet pet) {
         return PetResponse.builder()
-                .id(pet.getId())
-                .userId(pet.getUser().getId())
-                .name(pet.getName())
-                .species(pet.getSpecies())
-                .breed(pet.getBreed())
-                .birthDate(pet.getBirthDate())
-                .gender(pet.getGender())
-                .isNeutered(pet.isNeutered())
-                .profileImageUrl(pet.getProfileImageUrl())
-                .diseases(pet.getDiseases())
-                .createdAt(pet.getCreatedAt())
-                .updatedAt(pet.getUpdatedAt())
-                .build();
+            .id(pet.getId())
+            .userId(pet.getUser().getId())
+            .name(pet.getName())
+            .species(pet.getSpecies())
+            .breed(pet.getBreed())
+            .birthDate(pet.getBirthDate())
+            .isBirthDateUnknown(pet.isBirthDateUnknown())
+            .gender(pet.getGender())
+            .isNeutered(pet.isNeutered())
+            .weight(pet.getWeight())
+            .isWeightUnknown(pet.isWeightUnknown())
+            .registrationNumber(pet.getRegistrationNumber())
+            .hasAllergy(pet.getHasAllergy())
+            .allergyDescription(pet.getAllergyDescription())
+            .profileImageUrl(pet.getProfileImageUrl())
+            .diseases(pet.getDiseases())
+            .createdAt(pet.getCreatedAt())
+            .updatedAt(pet.getUpdatedAt())
+            .build();
     }
 
-    /** Pet 목록 → PetResponse 목록 */
     public List<PetResponse> toResponseList(List<Pet> pets) {
-        return pets.stream()
-                .map(this::toResponse)
-                .toList();
+        return pets.stream().map(this::toResponse).toList();
     }
 
-    /** PetGuardian → PetGuardianResponse. 보호자 목록·추가 응답에 사용 */
     public PetGuardianResponse toGuardianResponse(PetGuardian guardian) {
         return PetGuardianResponse.builder()
-                .id(guardian.getId())
-                .userId(guardian.getUser().getId())
-                .role(guardian.getRole())
-                .build();
+            .id(guardian.getId())
+            .userId(guardian.getUser().getId())
+            .role(guardian.getRole())
+            .build();
     }
 
-    /** PetGuardian 목록 → PetGuardianResponse 목록 */
     public List<PetGuardianResponse> toGuardianResponseList(List<PetGuardian> guardians) {
-        return guardians.stream()
-                .map(this::toGuardianResponse)
-                .toList();
+        return guardians.stream().map(this::toGuardianResponse).toList();
     }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetCreateRequest.java
@@ -4,19 +4,22 @@ import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetDisease;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.*;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Set;
 
-/**
- * 반려동물 등록 요청. POST /api/pets body.
- * 요청자는 메인 보호자(pet.user)로 저장됨.
+/** 수정 3월 18일
+ * 반려동물 등록 요청.
+ *
+ * ✅ 추가: weight, isWeightUnknown
+ * ✅ 추가: registrationNumber (동물등록번호 15자리)
+ * ✅ 추가: isBirthDateUnknown
+ * ✅ 추가: hasAllergy, allergyDescription
+ * ✅ 변경: diseases 최대 5개 제한 (기획서 step3)
  */
 @Getter
 @Builder
@@ -25,7 +28,7 @@ import java.util.Set;
 public class PetCreateRequest {
 
     @NotBlank(message = "이름은 필수입니다.")
-    @Size(max = 100)
+    @Size(min = 1, max = 20, message = "이름은 1~20자 이내여야 합니다.")
     private String name;
 
     @Size(max = 50)
@@ -34,18 +37,40 @@ public class PetCreateRequest {
     @Size(max = 100)
     private String breed;
 
+    /** 출생일 (isBirthDateUnknown=true이면 null 허용) */
     private LocalDate birthDate;
+
+    /** 출생일 모름 체크박스. true이면 birthDate 무시 */
+    private boolean isBirthDateUnknown = false;
 
     private Gender gender;
 
     private Boolean isNeutered;
 
-    /** 프로필 이미지 URL. Pet 엔티티가 TEXT 타입이므로 길이 제한 없음 */
+    /** 체중 (kg). isWeightUnknown=true이면 null 허용 */
+    private BigDecimal weight;
+
+    /** 체중 모름 체크박스 */
+    private boolean isWeightUnknown = false;
+
+    /**
+     * 동물등록번호. 숫자만, 최대 15자리. 선택.
+     */
+    @Pattern(regexp = "^[0-9]{0,15}$", message = "동물등록번호는 숫자 15자리 이내여야 합니다.")
+    private String registrationNumber;
+
+    /** 알레르기 여부 (있어요/없어요). null이면 미응답 */
+    private Boolean hasAllergy;
+
+    /** 알레르기 직접 입력 내용. hasAllergy=true일 때 사용 */
+    private String allergyDescription;
+
     private String profileImageUrl;
 
     /**
-     * 질병 목록 (선택). 입력 시 해당 질병에 맞는 케어 템플릿이 자동 생성됨.
-     * 예: [DIABETES, ARTHRITIS]
+     * 질병 목록. 최대 5개.
+     * 기획서: 심장병, 신장질환, 암, 안과질환, 쿠싱 증후군, 관절염
      */
+    @Size(max = 5, message = "질병은 최대 5개까지 선택 가능합니다.")
     private Set<PetDisease> diseases;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/request/PetUpdateRequest.java
@@ -1,19 +1,21 @@
 package com.newleaseonlife.SafeDogBe.domain.pet.dto.request;
 
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetDisease;
 
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.*;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Set;
 
-/**
- * 반려동물 수정 요청. PATCH /api/pets/{petId} body.
- * null 필드는 변경하지 않음(부분 수정).
+/** 3월 18일 수정
+ * 반려동물 수정 요청. null 필드는 변경하지 않음(부분 수정).
+ *
+ * ✅ 추가: weight, isWeightUnknown, registrationNumber,
+ *          isBirthDateUnknown, hasAllergy, allergyDescription, diseases
  */
 @Getter
 @Builder
@@ -21,7 +23,7 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class PetUpdateRequest {
 
-    @Size(max = 100)
+    @Size(min = 1, max = 20)
     private String name;
 
     @Size(max = 50)
@@ -31,11 +33,22 @@ public class PetUpdateRequest {
     private String breed;
 
     private LocalDate birthDate;
+    private Boolean isBirthDateUnknown;
 
     private Gender gender;
-
     private Boolean isNeutered;
 
-    /** 프로필 이미지 URL. Pet 엔티티가 TEXT 타입이므로 길이 제한 없음 */
+    private BigDecimal weight;
+    private Boolean isWeightUnknown;
+
+    @Pattern(regexp = "^[0-9]{0,15}$", message = "동물등록번호는 숫자 15자리 이내여야 합니다.")
+    private String registrationNumber;
+
+    private Boolean hasAllergy;
+    private String allergyDescription;
+
     private String profileImageUrl;
+
+    @Size(max = 5, message = "질병은 최대 5개까지 선택 가능합니다.")
+    private Set<PetDisease> diseases;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/dto/response/PetResponse.java
@@ -1,20 +1,20 @@
+// domain/pet/dto/response/PetResponse.java
 package com.newleaseonlife.SafeDogBe.domain.pet.dto.response;
 
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetDisease;
+import lombok.*;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Set;
 
-/**
- * 반려동물 응답. 조회·등록·수정 API 응답에 사용.
- * 보호자 목록은 GET /api/pets/{petId}/guardians 로 별도 조회.
+/** 수정 3월 18일
+ * 반려동물 응답 DTO.
+ *
+ * ✅ 추가: weight, isWeightUnknown, registrationNumber,
+ *          isBirthDateUnknown, hasAllergy, allergyDescription
  */
 @Getter
 @Builder
@@ -23,17 +23,20 @@ import java.util.Set;
 public class PetResponse {
 
     private Long id;
-    /** 메인 보호자(소유자) ID */
     private Long userId;
     private String name;
     private String species;
     private String breed;
     private LocalDate birthDate;
+    private boolean isBirthDateUnknown;
     private Gender gender;
-    /** 중성화 여부 */
     private boolean isNeutered;
+    private BigDecimal weight;
+    private boolean isWeightUnknown;
+    private String registrationNumber;
+    private Boolean hasAllergy;
+    private String allergyDescription;
     private String profileImageUrl;
-    /** 질병 목록. 등록된 질병이 없으면 빈 Set */
     private Set<PetDisease> diseases;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/Pet.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/Pet.java
@@ -4,43 +4,25 @@ import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.Gender;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetDisease;
 import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.ForeignKey;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import jakarta.persistence.*;
+import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
- * 반려동물 엔티티. 메인 보호자(user)와 보호자 목록(guardians)을 가짐.
- * Pet 삭제 시 guardians는 cascade + orphanRemoval로 함께 삭제됨.
+ * 수정 3월 18일 반려동물 엔티티.
+ * <p>
+ * ✅ 추가: weight, isWeightUnknown, registrationNumber, isBirthDateUnknown, hasAllergy,
+ * allergyDescription ✅ 제거: PetDisease.ALLERGY → hasAllergy/allergyDescription 필드로 분리
+ * <p>
+ * ⚠️ 단방향 원칙: - [기존 리팩토링 문서 오류] guardians(@OneToMany) 필드가 있었음 → 제거 - PetGuardian → Pet 단방향
+ * @ManyToOne 유지 - 보호자 조회/삭제는 PetGuardianRepository에서만 처리
  */
 @Entity
 @Table(name = "pets")
@@ -49,86 +31,180 @@ import java.util.Set;
 @EntityListeners(AuditingEntityListener.class)
 public class Pet {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
 
-    /** 메인 보호자(소유자). pets.user_id FK */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_pets_user"))
-    private User user;
+  /**
+   * 메인 보호자(소유자). Pet → User 단방향
+   */
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false, foreignKey = @ForeignKey(name = "fk_pets_user"))
+  private User user;
 
-    /** 보호자 목록(OWNER, CAREGIVER). Pet 삭제 시 함께 삭제, guardian 제거 시 DB에서도 삭제(orphanRemoval) */
-    @OneToMany(mappedBy = "pet", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PetGuardian> guardians = new ArrayList<>();
+  @Column(nullable = false, length = 100)
+  private String name;
 
-    @Column(nullable = false, length = 100)
-    private String name;
+  /**
+   * 종 (강아지/고양이)
+   */
+  @Column(length = 50)
+  private String species;
 
-    @Column(length = 50)
-    private String species;
+  @Column(length = 100)
+  private String breed;
 
-    @Column(length = 100)
-    private String breed;
+  private LocalDate birthDate;
 
-    private LocalDate birthDate;
+  /**
+   * 출생일을 모르는 경우 true. true이면 birthDate는 null
+   */
+  @Column(nullable = false)
+  private boolean isBirthDateUnknown = false;
 
-    @Enumerated(EnumType.STRING)
-    @Column(length = 10)
-    private Gender gender;
+  @Enumerated(EnumType.STRING)
+  @Column(length = 10)
+  private Gender gender;
 
-    @Column(nullable = false)
-    private boolean isNeutered = false;
+  @Column(nullable = false)
+  private boolean isNeutered = false;
 
-    /** 프로필 이미지 URL. S3 URL 길이 대비 TEXT 타입 (User.profileImageUrl과 동일) */
-    @Column(columnDefinition = "TEXT")
-    private String profileImageUrl;
+  /**
+   * 체중 (kg). 소수점 1자리까지 허용. isWeightUnknown=true이면 null 허용.
+   */
+  @Column(precision = 5, scale = 1)
+  private BigDecimal weight;
 
-    /**
-     * 질병 목록. 등록 시 질병별 CareTemplate 자동 생성에 사용.
-     * pet_diseases 별도 테이블에 저장. 비어있으면 질병 없음.
-     */
-    @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(
-            name = "pet_diseases",
-            joinColumns = @JoinColumn(name = "pet_id", foreignKey = @ForeignKey(name = "fk_pet_diseases_pet"))
-    )
-    @Enumerated(EnumType.STRING)
-    @Column(name = "disease", length = 30, nullable = false)
-    private Set<PetDisease> diseases = new HashSet<>();
+  /**
+   * 체중을 모르는 경우 true. true이면 weight는 null
+   */
+  @Column(nullable = false)
+  private boolean isWeightUnknown = false;
 
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+  /**
+   * 동물등록번호. 숫자만, 최대 15자리. 선택 입력.
+   */
+  @Column(length = 15)
+  private String registrationNumber;
 
-    /** 수정 일시. JPA Auditing 자동 갱신 */
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime updatedAt;
+  /**
+   * 알레르기 여부. 기획서 step3 알레르기 '있어요/없어요'
+   */
+  private Boolean hasAllergy;
 
-    @Builder
-    public Pet(User user, String name, String species, String breed, LocalDate birthDate,
-               Gender gender, boolean isNeutered, String profileImageUrl, Set<PetDisease> diseases) {
-        this.user = user;
-        this.name = name;
-        this.species = species;
-        this.breed = breed;
-        this.birthDate = birthDate;
-        this.gender = gender;
-        this.isNeutered = isNeutered;
-        this.profileImageUrl = profileImageUrl;
-        if (diseases != null) this.diseases = diseases;
-    }
+  /**
+   * 알레르기 직접 입력 내용. hasAllergy=true일 때만 사용.
+   */
+  @Column(columnDefinition = "TEXT")
+  private String allergyDescription;
 
-    /** 정보 수정. null이 아닌 필드만 반영. updatedAt은 @LastModifiedDate가 자동 갱신 */
-    public void update(String name, String species, String breed, LocalDate birthDate,
-                       Gender gender, Boolean isNeutered, String profileImageUrl) {
-        if (name != null) this.name = name;
-        if (species != null) this.species = species;
-        if (breed != null) this.breed = breed;
-        if (birthDate != null) this.birthDate = birthDate;
-        if (gender != null) this.gender = gender;
-        if (isNeutered != null) this.isNeutered = isNeutered;
-        if (profileImageUrl != null) this.profileImageUrl = profileImageUrl;
-    }
+  @Column(columnDefinition = "TEXT")
+  private String profileImageUrl;
+
+  /**
+   * 질병 목록. 최대 5개. pet_diseases 별도 테이블. ElementCollection은 Pet → 단방향이므로 원칙 준수.
+   */
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(
+      name = "pet_diseases",
+      joinColumns = @JoinColumn(name = "pet_id", foreignKey = @ForeignKey(name = "fk_pet_diseases_pet"))
+  )
+  @Enumerated(EnumType.STRING)
+  @Column(name = "disease", length = 30, nullable = false)
+  private Set<PetDisease> diseases = new HashSet<>();
+
+  @CreatedDate
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+
+  @Builder
+  public Pet(User user, String name, String species, String breed,
+      LocalDate birthDate, boolean isBirthDateUnknown,
+      Gender gender, boolean isNeutered,
+      BigDecimal weight, boolean isWeightUnknown,
+      String registrationNumber,
+      Boolean hasAllergy, String allergyDescription,
+      String profileImageUrl, Set<PetDisease> diseases) {
+    this.user = user;
+    this.name = name;
+    this.species = species;
+    this.breed = breed;
+    this.birthDate = birthDate;
+    this.isBirthDateUnknown = isBirthDateUnknown;
+    this.gender = gender;
+    this.isNeutered = isNeutered;
+    this.weight = weight;
+    this.isWeightUnknown = isWeightUnknown;
+    this.registrationNumber = registrationNumber;
+    this.hasAllergy = hasAllergy;
+    this.allergyDescription = allergyDescription;
+    this.profileImageUrl = profileImageUrl;
+      if (diseases != null) {
+          this.diseases = diseases;
+      }
+  }
+
+  /**
+   * 정보 수정. null이 아닌 필드만 반영
+   */
+  public void update(String name, String species, String breed,
+      LocalDate birthDate, Boolean isBirthDateUnknown,
+      Gender gender, Boolean isNeutered,
+      BigDecimal weight, Boolean isWeightUnknown,
+      String registrationNumber,
+      Boolean hasAllergy, String allergyDescription,
+      String profileImageUrl) {
+      if (name != null) {
+          this.name = name;
+      }
+      if (species != null) {
+          this.species = species;
+      }
+      if (breed != null) {
+          this.breed = breed;
+      }
+      if (birthDate != null) {
+          this.birthDate = birthDate;
+      }
+      if (isBirthDateUnknown != null) {
+          this.isBirthDateUnknown = isBirthDateUnknown;
+      }
+      if (gender != null) {
+          this.gender = gender;
+      }
+      if (isNeutered != null) {
+          this.isNeutered = isNeutered;
+      }
+      if (weight != null) {
+          this.weight = weight;
+      }
+      if (isWeightUnknown != null) {
+          this.isWeightUnknown = isWeightUnknown;
+      }
+      if (registrationNumber != null) {
+          this.registrationNumber = registrationNumber;
+      }
+      if (hasAllergy != null) {
+          this.hasAllergy = hasAllergy;
+      }
+      if (allergyDescription != null) {
+          this.allergyDescription = allergyDescription;
+      }
+      if (profileImageUrl != null) {
+          this.profileImageUrl = profileImageUrl;
+      }
+  }
+
+  /**
+   * 질병 목록 수정
+   */
+  public void updateDiseases(Set<PetDisease> diseases) {
+    this.diseases.clear();
+    if (diseases != null)
+      this.diseases.addAll(diseases);
+  }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/enums/PetDisease.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/entity/enums/PetDisease.java
@@ -1,73 +1,74 @@
 package com.newleaseonlife.SafeDogBe.domain.pet.entity.enums;
 
-import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
-import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.RepeatCycle;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-/**
- * 반려동물 질병 유형. 등록 시 질병별 기본 체크리스트 템플릿 자동 생성에 사용.
- * defaultTemplates()로 해당 질병에 맞는 CareTemplate 정보를 반환한다.
+/** 수정_3월18일
+ * 반려동물 질병 유형 (기획서 기준 6종).
+ * 등록 시 질병별 기본 체크리스트 자동 생성에 사용.
+ * defaultCheckItems()로 해당 질병의 기본 체크 항목 문자열 목록을 반환한다.
+ *
+ * ✅ 변경: DIABETES, ALLERGY, SKIN_DISEASE 제거
+ * ✅ 변경: EYE_DISEASE, CUSHING 추가
+ * ✅ 변경: 기본 체크리스트 내용을 기획서 명세 기준으로 전면 교체
+ * ✅ 알레르기는 Pet.hasAllergy + Pet.allergyDescription 필드로 분리
  */
 @Getter
 @RequiredArgsConstructor
 public enum PetDisease {
 
-    DIABETES("당뇨",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "당뇨약 복용", "처방에 따라 인슐린 또는 경구약 복용", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.MEAL,    "식이 관리",   "당뇨 맞춤 식단 급여 (고단백·저탄수화물)", RepeatCycle.DAILY)
-            )),
+  HEART_DISEASE("심장병", List.of(
+      "수면 중 안정 시 호흡수(SRR) 측정 및 기록",
+      "점막(혀/잇몸) 색깔 및 기침 양상 관찰",
+      "날씨 확인 후 산책",
+      "식후 즉시 활동 금지 및 휴식 유도"
+  )),
 
-    HEART_DISEASE("심장병",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "심장약 복용",  "처방에 따라 심장 관련 약 복용", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.HOSPITAL, "심장 정기검진", "수의사 지시에 따른 정기 검진", RepeatCycle.MONTHLY)
-            )),
+  KIDNEY_DISEASE("신장질환", List.of(
+      "피부 탄력(탈수) 테스트",
+      "구강 및 잇몸 상태(악취, 궤양) 관찰",
+      "물그릇 세척 및 신선한 물 교체",
+      "음수 유도(입 가까이 물 대주기)"
+  )),
 
-    ARTHRITIS("관절염",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "관절약/보조제 복용", "처방 또는 보조제 급여", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.WALK,     "짧은 산책",          "과격하지 않은 가벼운 산책 (15~20분)", RepeatCycle.DAILY)
-            )),
+  CANCER("암", List.of(
+      "환부 소독 및 드레싱 교체",
+      "종양 크기 변화 및 새 멍울 촉진",
+      "통증 신호 및 컨디션(식욕 등) 모니터링",
+      "체온 측정 및 미열 확인",
+      "반려동물과 5분 놀이하기"
+  )),
 
-    KIDNEY_DISEASE("신장병",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "신장약 복용",  "처방에 따라 신장 관련 약 복용", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.MEAL,     "신장 식이 관리", "저단백·저인 맞춤 식단 급여", RepeatCycle.DAILY)
-            )),
+  EYE_DISEASE("안과질환", List.of(
+      "안구 세정 및 눈 주변 분비물 닦기",
+      "인공눈물 점안",
+      "안구 통증, 충혈, 혼탁도 관찰",
+      "점안 후 눈 비비지 않도록 제지"
+  )),
 
-    ALLERGY("알레르기",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "항히스타민/처방약 복용", "수의사 처방 약 복용", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.BATH,     "정기 목욕·피부 관리",   "알레르겐 제거를 위한 주기적 목욕", RepeatCycle.WEEKLY)
-            )),
+  CUSHING("쿠싱 증후군", List.of(
+      "복부 팽만(올챙이 배) 상태 확인",
+      "피부 발진, 각질 및 피부 얇아짐 관찰",
+      "음수량 및 배뇨 횟수 관찰",
+      "근육 감소 및 보행 상태 확인",
+      "피부 접히는 부위 청결 관리 및 보습제 도포"
+  )),
 
-    SKIN_DISEASE("피부병",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "피부약/연고 도포",  "처방에 따라 피부약·연고 적용", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.BATH,     "약용 샴푸 목욕",    "수의사 권장 약용 샴푸로 목욕", RepeatCycle.WEEKLY)
-            )),
+  ARTHRITIS("관절염", List.of(
+      "기상 직후 보행 및 절뚝임 상태 관찰",
+      "아픈 관절 부위 온찜질 및 마사지 수행",
+      "수동 관절 운동(PROM) 수행",
+      "발바닥 털 정리 및 미끄럼 방지 점검"
+  ));
 
-    CANCER("암",
-            List.of(
-                    new DefaultTemplate(CareType.MEDICINE, "항암/처방약 복용",  "처방에 따라 항암제·보조약 복용", RepeatCycle.DAILY),
-                    new DefaultTemplate(CareType.HOSPITAL, "항암 정기 방문",    "치료 계획에 따른 병원 방문", RepeatCycle.MONTHLY)
-            ));
+  /** 사용자 노출용 한국어 표시명 */
+  private final String description;
 
-    /** 사용자 노출용 한국어 표시명 */
-    private final String description;
-
-    /** 해당 질병에 맞는 기본 케어 템플릿 목록 */
-    private final List<DefaultTemplate> defaultTemplates;
-
-    /**
-     * 자동 생성 CareTemplate 정보를 담는 값 객체.
-     * Pet 등록 시 이 정보를 기반으로 CareTemplate 엔티티를 생성한다.
-     */
-    public record DefaultTemplate(CareType careType, String title, String content, RepeatCycle repeatCycle) {
-    }
+  /**
+   * 해당 질병의 기본 케어 체크리스트 항목 문자열 목록.
+   * Pet 등록 시 이 목록을 기반으로 CareTemplate 엔티티를 생성한다.
+   */
+  private final List<String> defaultCheckItems;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/service/PetService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/service/PetService.java
@@ -1,7 +1,10 @@
+// domain/pet/service/PetService.java
 package com.newleaseonlife.SafeDogBe.domain.pet.service;
 
 import com.newleaseonlife.SafeDogBe.domain.care.entity.CareTemplate;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
 import com.newleaseonlife.SafeDogBe.domain.care.repository.CareTemplateRepository;
+import com.newleaseonlife.SafeDogBe.domain.pet.converter.PetConverter;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.GuardianAddRequest;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.PetCreateRequest;
 import com.newleaseonlife.SafeDogBe.domain.pet.dto.request.PetUpdateRequest;
@@ -10,7 +13,6 @@ import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.PetGuardian;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetDisease;
-import com.newleaseonlife.SafeDogBe.domain.pet.converter.PetConverter;
 import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetGuardianRepository;
 import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetRepository;
 import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
@@ -21,7 +23,6 @@ import com.newleaseonlife.SafeDogBe.global.error.domain.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,9 +30,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-/**
- * 반려동물(Pet) 도메인 서비스. CRUD, 보호자(Guardian) 추가·삭제·목록 조회.
- * 반려동물 소유자(pet.user)만 수정·삭제·보호자 관리 가능.
+/** 3월 18일 수정
+ * ✅ 수정: create() — 신규 필드(weight, registrationNumber 등) 반영
+ * ✅ 수정: update() — 신규 필드 반영, diseases 수정 지원
+ * ✅ 수정: createDefaultCareTemplates() — PetDisease.defaultCheckItems() 기반 DISEASE_CARE 템플릿 생성
  */
 @Slf4j
 @Service
@@ -45,148 +47,143 @@ public class PetService {
     private final CareTemplateRepository careTemplateRepository;
     private final PetConverter petConverter;
 
-    /** 내가 소유한 반려동물 목록(최신순) */
     public List<PetResponse> findMyPets(Long userId) {
-        log.debug("[PetService] findMyPets userId={}", userId);
-        List<Pet> pets = petRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
-        return petConverter.toResponseList(pets);
+        return petConverter.toResponseList(
+            petRepository.findAllByUserIdOrderByCreatedAtDesc(userId));
     }
 
-    /** 반려동물 단건 조회. 소유자만 조회 가능(보호자 목록 포함 조회는 getGuardians 사용) */
     public PetResponse findById(Long petId, Long userId) {
-        log.debug("[PetService] findById petId={}, userId={}", petId, userId);
         return petConverter.toResponse(getPetAsOwnerOrThrow(petId, userId));
     }
 
-    /** 반려동물 등록. 요청자를 메인 보호자(pet.user)로 저장. 질병 입력 시 질병별 CareTemplate 자동 생성 */
     @Transactional
-    public PetResponse create(Long userId, PetCreateRequest request) {
-        log.info("[PetService] create userId={}, name={}", userId, request.getName());
+    public PetResponse create(Long userId, PetCreateRequest req) {
+        log.info("[PetService] create userId={}, name={}", userId, req.getName());
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        boolean isNeutered = request.getIsNeutered() != null && request.getIsNeutered();
-        Set<PetDisease> diseases = request.getDiseases() != null ? request.getDiseases() : Set.of();
+        Set<PetDisease> diseases = req.getDiseases() != null ? req.getDiseases() : Set.of();
+
         Pet pet = Pet.builder()
-                .user(user)
-                .name(request.getName())
-                .species(request.getSpecies())
-                .breed(request.getBreed())
-                .birthDate(request.getBirthDate())
-                .gender(request.getGender())
-                .isNeutered(isNeutered)
-                .profileImageUrl(request.getProfileImageUrl())
-                .diseases(diseases)
-                .build();
+            .user(user)
+            .name(req.getName())
+            .species(req.getSpecies())
+            .breed(req.getBreed())
+            .birthDate(req.getBirthDate())
+            .isBirthDateUnknown(req.isBirthDateUnknown())
+            .gender(req.getGender())
+            .isNeutered(req.getIsNeutered() != null && req.getIsNeutered())
+            .weight(req.getWeight())
+            .isWeightUnknown(req.isWeightUnknown())
+            .registrationNumber(req.getRegistrationNumber())
+            .hasAllergy(req.getHasAllergy())
+            .allergyDescription(req.getAllergyDescription())
+            .profileImageUrl(req.getProfileImageUrl())
+            .diseases(diseases)
+            .build();
         petRepository.save(pet);
 
-        // 질병 유형별 기본 케어 템플릿 자동 생성
+        // 질병별 기본 DISEASE_CARE 케어 템플릿 자동 생성
         if (!diseases.isEmpty()) {
             createDefaultCareTemplates(pet, diseases);
         }
 
-        log.info("[PetService] create 완료 petId={}, diseases={}", pet.getId(), diseases);
+        log.info("[PetService] create 완료 petId={}", pet.getId());
         return petConverter.toResponse(pet);
     }
 
-    /** 질병 목록을 기반으로 PetDisease에 정의된 기본 CareTemplate 일괄 생성 */
+    @Transactional
+    public PetResponse update(Long petId, Long userId, PetUpdateRequest req) {
+        log.info("[PetService] update petId={}, userId={}", petId, userId);
+        Pet pet = getPetAsOwnerOrThrow(petId, userId);
+
+        pet.update(
+            req.getName(), req.getSpecies(), req.getBreed(),
+            req.getBirthDate(), req.getIsBirthDateUnknown(),
+            req.getGender(), req.getIsNeutered(),
+            req.getWeight(), req.getIsWeightUnknown(),
+            req.getRegistrationNumber(),
+            req.getHasAllergy(), req.getAllergyDescription(),
+            req.getProfileImageUrl()
+        );
+
+        // 질병 목록 수정 시 업데이트
+        if (req.getDiseases() != null) {
+            pet.updateDiseases(req.getDiseases());
+        }
+
+        return petConverter.toResponse(pet);
+    }
+
+    @Transactional
+    public void delete(Long petId, Long userId) {
+        petRepository.delete(getPetAsOwnerOrThrow(petId, userId));
+    }
+
+    public List<PetGuardianResponse> getGuardians(Long petId, Long userId) {
+        Pet pet = getPetAsOwnerOrThrow(petId, userId);
+        return petConverter.toGuardianResponseList(
+            petGuardianRepository.findByPetIdOrderByIdAsc(pet.getId()));
+    }
+
+    @Transactional
+    public PetGuardianResponse addGuardian(Long petId, Long ownerUserId, GuardianAddRequest req) {
+        Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
+        User targetUser = userRepository.findById(req.getUserId())
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        if (petGuardianRepository.existsByPetIdAndUserId(pet.getId(), req.getUserId())) {
+            throw new BusinessException(PetErrorCode.PET_GUARDIAN_ALREADY_EXISTS);
+        }
+
+        PetGuardian guardian = PetGuardian.builder()
+            .user(targetUser).pet(pet).role(req.getRole()).build();
+        return petConverter.toGuardianResponse(petGuardianRepository.save(guardian));
+    }
+
+    /** 보호자 제거. 소유자만 가능 */
+    @Transactional
+    public void removeGuardian(Long petId, Long ownerUserId, Long guardianUserId) {
+        log.info("[PetService] removeGuardian petId={}, ownerUserId={}, guardianUserId={}",
+            petId, ownerUserId, guardianUserId);
+        Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
+        PetGuardian guardian = petGuardianRepository.findByPetIdAndUserId(pet.getId(), guardianUserId)
+            .orElseThrow(() -> new BusinessException(PetErrorCode.PET_GUARDIAN_NOT_FOUND));
+
+        // ✅ [수정] Repository에서 직접 삭제
+        petGuardianRepository.delete(guardian);
+        log.info("[PetService] removeGuardian 완료 guardianId={}", guardian.getId());
+    }
+
+    /**
+     * 질병별 기본 DISEASE_CARE 케어 템플릿 생성.
+     *
+     * ✅ 변경: 기존 MEDICINE/HOSPITAL 타입 → DISEASE_CARE 타입
+     * ✅ 변경: defaultTemplates() → defaultCheckItems() 기반으로 각 체크 항목을 개별 CareTemplate으로 생성
+     */
     private void createDefaultCareTemplates(Pet pet, Set<PetDisease> diseases) {
         List<CareTemplate> templates = new ArrayList<>();
         for (PetDisease disease : diseases) {
-            for (PetDisease.DefaultTemplate tmpl : disease.getDefaultTemplates()) {
+            for (String checkItem : disease.getDefaultCheckItems()) {
                 templates.add(CareTemplate.builder()
-                        .pet(pet)
-                        .careType(tmpl.careType())
-                        .title("[" + disease.getDescription() + "] " + tmpl.title())
-                        .content(tmpl.content())
-                        .repeatCycle(tmpl.repeatCycle())
-                        .build());
+                    .pet(pet)
+                    .careType(CareType.DISEASE_CARE)
+                    .title("[" + disease.getDescription() + "] " + checkItem)
+                    // 주기 미설정 → 매일 생성
+                    .build());
             }
         }
         careTemplateRepository.saveAll(templates);
         log.info("[PetService] 질병 기반 CareTemplate {}개 자동 생성 petId={}", templates.size(), pet.getId());
     }
 
-    /** 반려동물 정보 수정. 소유자만 가능 */
-    @Transactional
-    public PetResponse update(Long petId, Long userId, PetUpdateRequest request) {
-        log.info("[PetService] update petId={}, userId={}", petId, userId);
-        Pet pet = getPetAsOwnerOrThrow(petId, userId);
-        pet.update(
-                request.getName(),
-                request.getSpecies(),
-                request.getBreed(),
-                request.getBirthDate(),
-                request.getGender(),
-                request.getIsNeutered(),
-                request.getProfileImageUrl()
-        );
-        log.info("[PetService] update 완료 petId={}", petId);
-        return petConverter.toResponse(pet);
-    }
-
-    /** 반려동물 삭제. 소유자만 가능. pet_guardian 행은 cascade로 함께 삭제 */
-    @Transactional
-    public void delete(Long petId, Long userId) {
-        log.info("[PetService] delete petId={}, userId={}", petId, userId);
-        Pet pet = getPetAsOwnerOrThrow(petId, userId);
-        petRepository.delete(pet);
-        log.info("[PetService] delete 완료 petId={}", petId);
-    }
-
-    /** 해당 반려동물의 보호자 목록 조회. 소유자만 호출 가능 */
-    public List<PetGuardianResponse> getGuardians(Long petId, Long userId) {
-        log.debug("[PetService] getGuardians petId={}, userId={}", petId, userId);
-        Pet pet = getPetAsOwnerOrThrow(petId, userId);
-        List<PetGuardian> guardians = petGuardianRepository.findByPetIdOrderByIdAsc(pet.getId());
-        return petConverter.toGuardianResponseList(guardians);
-    }
-
-    /** 보호자 추가. 소유자만 가능. 이미 등록된 사용자면 PET_GUARDIAN_ALREADY_EXISTS */
-    @Transactional
-    public PetGuardianResponse addGuardian(Long petId, Long ownerUserId, GuardianAddRequest request) {
-        log.info("[PetService] addGuardian petId={}, ownerUserId={}, targetUserId={}, role={}",
-                petId, ownerUserId, request.getUserId(), request.getRole());
-        Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
-        User targetUser = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-        if (petGuardianRepository.existsByPetIdAndUserId(pet.getId(), request.getUserId())) {
-            log.warn("[PetService] addGuardian 실패 - 이미 보호자로 등록됨 petId={}, userId={}", petId, request.getUserId());
-            throw new BusinessException(PetErrorCode.PET_GUARDIAN_ALREADY_EXISTS);
-        }
-        PetGuardian guardian = PetGuardian.builder()
-                .user(targetUser)
-                .pet(pet)
-                .role(request.getRole())
-                .build();
-        // pet.getGuardians().add()와 repository.save() 동시 호출 시 중복 INSERT 가능 → save()만 사용
-        PetGuardian saved = petGuardianRepository.save(guardian);
-        log.info("[PetService] addGuardian 완료 guardianId={}", saved.getId());
-        return petConverter.toGuardianResponse(saved);
-    }
-
-    /** 보호자 제거. 소유자만 가능. 지정한 userId의 보호자 연결만 삭제 */
-    @Transactional
-    public void removeGuardian(Long petId, Long ownerUserId, Long guardianUserId) {
-        log.info("[PetService] removeGuardian petId={}, ownerUserId={}, guardianUserId={}", petId, ownerUserId, guardianUserId);
-        Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
-        PetGuardian guardian = petGuardianRepository.findByPetIdAndUserId(pet.getId(), guardianUserId)
-                .orElseThrow(() -> {
-                    log.warn("[PetService] removeGuardian 실패 - 보호자 없음 petId={}, userId={}", petId, guardianUserId);
-                    return new BusinessException(PetErrorCode.PET_GUARDIAN_NOT_FOUND);
-                });
-        pet.getGuardians().remove(guardian);
-        log.info("[PetService] removeGuardian 완료 guardianId={} (orphanRemoval)", guardian.getId());
-    }
-
-    /** 반려동물 조회(소유자만). 없거나 권한 없으면 예외 */
     private Pet getPetAsOwnerOrThrow(Long petId, Long userId) {
         return petRepository.findByIdAndUserId(petId, userId)
-                .orElseThrow(() -> {
-                    if (petRepository.findById(petId).isEmpty()) {
-                        return new BusinessException(PetErrorCode.PET_NOT_FOUND);
-                    }
-                    return new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
-                });
+            .orElseThrow(() -> {
+                if (petRepository.findById(petId).isEmpty()) {
+                    return new BusinessException(PetErrorCode.PET_NOT_FOUND);
+                }
+                return new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
+            });
     }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/CareErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/CareErrorCode.java
@@ -1,0 +1,30 @@
+package com.newleaseonlife.SafeDogBe.global.error.domain;
+
+import com.newleaseonlife.SafeDogBe.global.error.ApiCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/** 케어 도메인 오류 코드 */
+@AllArgsConstructor
+@Getter
+public enum CareErrorCode implements ApiCode {
+
+  CARE_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "존재하지 않는 케어 템플릿입니다."),
+  CARE_TEMPLATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, 403, "해당 케어 템플릿에 접근 권한이 없습니다."),
+  CHECKLIST_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "존재하지 않는 체크리스트입니다."),
+  CHECKLIST_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, 400, "이미 완료 처리된 항목입니다."),
+  CHECKLIST_NOT_COMPLETED(HttpStatus.BAD_REQUEST, 400, "아직 완료되지 않은 항목입니다."),
+  CHECKLIST_DATE_NOT_TODAY(HttpStatus.BAD_REQUEST, 400, "오늘 날짜의 체크리스트만 수정할 수 있습니다."),
+  CHECKLIST_VERSION_CONFLICT(HttpStatus.CONFLICT, 409, "다른 보호자가 먼저 저장했습니다. 최신 내용을 확인해주세요."),
+  EXCRETION_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "존재하지 않는 배변 기록입니다."),
+  WEIGHT_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "존재하지 않는 체중 기록입니다."),
+  EXCRETION_STATUS_REQUIRED(HttpStatus.BAD_REQUEST, 400, "배변 상태(정상/이상) 값은 필수입니다.");
+
+  private final HttpStatus httpStatus;
+  private final Integer code;
+  private final String message;
+
+  @Override
+  public HttpStatus getHttpStatus() { return this.httpStatus; }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호

#75 

## 📌 작업 내용
#### ✅ checklist 도메인
- 당일 수정만 가능하도록 KST 기준 날짜 검증 추가
- 스케줄러 주기 판단 로직 `shouldGenerateToday()`로 개선
- 로그 90일 자동 삭제 배치 추가

#### 🆕 신규 기능
- `DailyExcretionRecord` (배변 상세 기록 — 소변/대변 상태)
- `DailyWeightRecord` (체중 수치 기록)

#### 🔧 코드 품질
- `IllegalArgumentException` / `IllegalStateException`
  → `BusinessException(CareErrorCode)` 통일
- `DailyExcretionRecord.pet` 중복 필드 제거

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
