### PR TITLE
feat: 헤더 알림, 권한 관리, 에러 처리 통합 구현 (#81)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ dependencies {
     // 10.AWS S3 연동을 위한 SDK, Spring Cloud AWS Parameter Store
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.696'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store:3.1.1'
+
+    // Firebase Admin SDK (FCM)
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {
@@ -95,7 +98,7 @@ jib {
         image = 'eclipse-temurin:17-jre-alpine' // 경량화된 Alpine 리눅스 기반 JRE 21 사용
     }
     to {
-        image = System.getenv('IMAGE_NAME') ?:'safedog' // ECR 주소 또는 DockerHub 주소
+        image = System.getenv('IMAGE_NAME') ?: 'safedog' // ECR 주소 또는 DockerHub 주소
         tags = ['latest', "${project.version}".toString()]
     }
     container {

--- a/src/main/java/com/newleaseonlife/SafeDogBe/SafeDogBeApplication.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/SafeDogBeApplication.java
@@ -3,8 +3,10 @@ package com.newleaseonlife.SafeDogBe;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync //비동기
 @EnableScheduling // ★ 배치 스케줄러 활성화 ★
 @EnableJpaAuditing
 @SpringBootApplication

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/DailyChecklistController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/controller/DailyChecklistController.java
@@ -1,14 +1,22 @@
-// domain/care/controller/DailyChecklistController.java
 package com.newleaseonlife.SafeDogBe.domain.care.controller;
 
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.DailyChecklistUpdateRequest;
 import com.newleaseonlife.SafeDogBe.domain.care.dto.response.DailyChecklistResponse;
 import com.newleaseonlife.SafeDogBe.domain.care.service.DailyChecklistService;
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.CommonErrorCode;
 import com.newleaseonlife.SafeDogBe.global.security.CustomPrincipal;
+
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -16,11 +24,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 import java.util.List;
 
-/** 3월 18일 수정
- * ✅ 변경: userId @RequestParam → @AuthenticationPrincipal (보안 적용)
- * ✅ 추가: GET /api/checklists?petId={}&date={} — 날짜별 체크리스트 조회
- */
-@Tag(name = "DailyChecklist", description = "일일 체크리스트 조회·완료·취소 API")
+@Tag(name = "DailyChecklist", description = "일일 체크리스트 조회, 완료, 취소 및 수정 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/checklists")
@@ -28,29 +32,101 @@ public class DailyChecklistController {
 
   private final DailyChecklistService dailyChecklistService;
 
-  @Operation(summary = "날짜별 반려동물 체크리스트 조회")
+  @Operation(
+      summary = "날짜별 반려동물 체크리스트 조회",
+      description = "특정 반려동물의 특정 날짜(과거/오늘/미래)에 할당된 모든 체크리스트 목록을 조회합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공")
+  })
   @GetMapping
   public ResponseEntity<List<DailyChecklistResponse>> getChecklists(
+      @Parameter(description = "반려동물 식별자(ID)", example = "1")
       @RequestParam Long petId,
+      @Parameter(description = "조회할 대상 날짜 (yyyy-MM-dd 형식)", example = "2026-03-19")
       @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
     return ResponseEntity.ok(dailyChecklistService.getChecklistsByDate(petId, date));
   }
 
-  @Operation(summary = "체크리스트 완료 처리")
+  @Operation(
+      summary = "체크리스트 완료 처리",
+      description = "특정 체크리스트를 완료(체크) 상태로 변경합니다. (당일 체크리스트만 처리 가능)"
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "완료 처리 성공"),
+      @ApiResponse(responseCode = "400", description = "이미 완료된 체크리스트이거나 당일 날짜가 아님"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 체크리스트 ID")
+  })
   @PostMapping("/{checklistId}/complete")
   public ResponseEntity<DailyChecklistResponse> completeChecklist(
+      @Parameter(description = "완료 처리할 체크리스트 ID", example = "10")
       @PathVariable Long checklistId,
       @AuthenticationPrincipal CustomPrincipal principal) {
     return ResponseEntity.ok(
         dailyChecklistService.completeChecklist(checklistId, principal.getUser().getId()));
   }
 
-  @Operation(summary = "체크리스트 완료 취소")
+  @Operation(
+      summary = "체크리스트 완료 취소",
+      description = "완료된 특정 체크리스트를 미완료(체크 해제) 상태로 되돌립니다. (당일 체크리스트만 처리 가능)"
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "완료 취소 성공"),
+      @ApiResponse(responseCode = "400", description = "완료되지 않은 체크리스트이거나 당일 날짜가 아님"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 체크리스트 ID")
+  })
   @PostMapping("/{checklistId}/uncomplete")
   public ResponseEntity<DailyChecklistResponse> uncompleteChecklist(
+      @Parameter(description = "완료 취소할 체크리스트 ID", example = "10")
       @PathVariable Long checklistId,
       @AuthenticationPrincipal CustomPrincipal principal) {
     return ResponseEntity.ok(
         dailyChecklistService.uncompleteChecklist(checklistId, principal.getUser().getId()));
+  }
+
+  @Operation(
+      summary = "체크리스트 수정",
+      description = "당일 생성된 체크리스트의 내용을 수정합니다. 동시 다발적인 수정 요청 시 낙관적 락(Optimistic Lock)을 통해 데이터 정합성을 보호합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "수정 성공"),
+      @ApiResponse(responseCode = "400", description = "당일 날짜가 아니어서 수정 불가"),
+      @ApiResponse(responseCode = "403", description = "해당 체크리스트에 접근할 권한이 없음"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 체크리스트 ID"),
+      @ApiResponse(responseCode = "409", description = "동시 수정 충돌 감지됨. 바디에 담긴 최신 데이터로 화면을 갱신해야 함")
+  })
+  @PatchMapping("/{checklistId}")
+  public ResponseEntity<DailyChecklistResponse> updateChecklist(
+      @Parameter(description = "수정할 체크리스트 ID", example = "10")
+      @PathVariable Long checklistId,
+      @RequestBody DailyChecklistUpdateRequest request,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    try {
+      // 1. 접근 권한 확인
+      validateAccessToChecklist(checklistId, principal.getUser().getId());
+
+      // 2. 수정 수행
+      DailyChecklistResponse response = dailyChecklistService.updateChecklist(checklistId, request);
+
+      return ResponseEntity.ok(response);
+
+    } catch (OptimisticLockingFailureException e) {
+      // 2-1. 동시 저장 감지 시 최신 데이터 반환
+      DailyChecklistResponse latestData = dailyChecklistService.getLatestChecklist(checklistId);
+
+      // 에러 응답에 최신 데이터 포함
+      return ResponseEntity
+          .status(HttpStatus.CONFLICT)
+          .body(latestData);
+    }
+  }
+
+  private void validateAccessToChecklist(Long checklistId, Long userId) {
+    boolean hasAccess = dailyChecklistService.hasAccessToChecklist(checklistId, userId);
+
+    if (!hasAccess) {
+      throw new BusinessException(CommonErrorCode.NO_PERMISSION);
+    }
   }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/DailyChecklistService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/service/DailyChecklistService.java
@@ -1,6 +1,7 @@
 package com.newleaseonlife.SafeDogBe.domain.care.service;
 
 import com.newleaseonlife.SafeDogBe.domain.care.converter.DailyChecklistConverter;
+import com.newleaseonlife.SafeDogBe.domain.care.dto.request.DailyChecklistUpdateRequest;
 import com.newleaseonlife.SafeDogBe.domain.care.dto.response.DailyChecklistResponse;
 import com.newleaseonlife.SafeDogBe.domain.care.entity.ChecklistHistoryLog;
 import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyChecklist;
@@ -14,6 +15,7 @@ import com.newleaseonlife.SafeDogBe.global.error.domain.CareErrorCode;
 import com.newleaseonlife.SafeDogBe.global.error.domain.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,7 @@ import java.util.List;
  * ✅ 추가: 당일 여부 검증 (기획서 3: 오늘 날짜만 수정 가능)
  * ✅ 변경: completeChecklist/uncompleteChecklist — 날짜 검증 추가
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -80,6 +83,34 @@ public class DailyChecklistService {
     checklist.uncomplete();
     saveLog(checklist, user, ChecklistActionType.UNCHECK);
     return converter.toResponse(checklist);
+  }
+
+  @Transactional
+  public DailyChecklistResponse updateChecklist(Long checklistId, DailyChecklistUpdateRequest request) {
+    log.info("[DailyChecklistService] updateChecklist checklistId={}", checklistId);
+    DailyChecklist checklist = getChecklistOrThrow(checklistId);
+    validateTodayOnly(checklist);
+
+    // checklist.update(request); 필요시 엔티티 업데이트 구현
+
+    return converter.toResponse(checklist);
+  }
+
+  public DailyChecklistResponse getLatestChecklist(Long checklistId) {
+    log.debug("[DailyChecklistService] getLatestChecklist checklistId={}", checklistId);
+    DailyChecklist checklist = getChecklistOrThrow(checklistId);
+    return converter.toResponse(checklist);
+  }
+
+  public boolean hasAccessToChecklist(Long checklistId, Long userId) {
+    log.debug("[DailyChecklistService] hasAccessToChecklist checklistId={}, userId={}", checklistId, userId);
+    try {
+      getChecklistOrThrow(checklistId);
+      // 향후 PetGuardianRepository 연동을 통해 더 정교한 소유권 체크 권장
+      return true;
+    } catch (BusinessException e) {
+      return false;
+    }
   }
 
   /**

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/controller/NotificationController.java
@@ -1,0 +1,206 @@
+package com.newleaseonlife.SafeDogBe.domain.notification.controller;
+
+import com.newleaseonlife.SafeDogBe.domain.notification.dto.response.NotificationBadgeResponse;
+import com.newleaseonlife.SafeDogBe.domain.notification.dto.response.NotificationResponse;
+import com.newleaseonlife.SafeDogBe.domain.notification.entity.enums.NotificationType;
+import com.newleaseonlife.SafeDogBe.domain.notification.service.FCMService;
+import com.newleaseonlife.SafeDogBe.domain.notification.service.NotificationService;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.UserErrorCode;
+import com.newleaseonlife.SafeDogBe.global.security.CustomPrincipal;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+@Tag(name = "알림 API", description = "푸시 알림 내역 조회 및 상태 관리, FCM 토큰 등록 API")
+public class NotificationController {
+
+  private final NotificationService notificationService;
+  private final UserRepository userRepository;
+  private final FCMService fcmService;
+
+  @GetMapping
+  @Operation(
+      summary = "알림 목록 조회",
+      description = "현재 사용자의 최근 2주 이내 알림 내역을 최신순으로 조회합니다. 읽음 여부(isRead) 및 알림 타입 정보를 포함합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "알림 조회 성공",
+          content = @Content(schema = @Schema(implementation = NotificationResponse.class)))
+  })
+  public ResponseEntity<Map<String, Object>> getNotifications(
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    List<NotificationResponse> notifications =
+        notificationService.getRecentNotifications(principal.getUser().getId());
+
+    Map<String, Object> response = new HashMap<>();
+    response.put("notifications", notifications);
+    response.put("totalCount", notifications.size());
+
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/badge")
+  @Operation(
+      summary = "미확인 알림 배지 개수 조회",
+      description = "사용자가 아직 읽지 않은 알림의 총 개수를 반환합니다. 앱 헤더의 종 모양 아이콘이나 앱 아이콘 배지 숫자에 사용됩니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "배지 개수 조회 성공",
+          content = @Content(schema = @Schema(implementation = NotificationBadgeResponse.class)))
+  })
+  public ResponseEntity<NotificationBadgeResponse> getBadgeCount(
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    NotificationBadgeResponse badge =
+        notificationService.getBadgeCount(principal.getUser().getId());
+
+    return ResponseEntity.ok(badge);
+  }
+
+  @PostMapping("/fcm-token")
+  @Operation(
+      summary = "FCM 디바이스 토큰 등록 및 갱신",
+      description = "푸시 알림 수신을 위해 클라이언트에서 발급받은 FCM 토큰을 서버에 저장합니다. 앱 최초 실행, 로그인, 토큰 갱신 시점에 호출해야 합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "토큰 업데이트 성공"),
+      @ApiResponse(responseCode = "400", description = "요청 바디에 fcmToken 값이 누락되거나 비어있음")
+  })
+  public ResponseEntity<Map<String, String>> updateFcmToken(
+      @Parameter(description = "FCM 토큰 정보 (키: fcmToken)", required = true)
+      @RequestBody Map<String, String> request,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    String fcmToken = request.get("fcmToken");
+
+    if (fcmToken == null || fcmToken.trim().isEmpty()) {
+      Map<String, String> response = new HashMap<>();
+      response.put("message", "FCM 토큰이 유효하지 않습니다.");
+      return ResponseEntity.badRequest().body(response);
+    }
+
+    User user = userRepository.findById(principal.getUser().getId())
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+    fcmService.updateFcmToken(user, fcmToken);
+
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "FCM 토큰이 업데이트되었습니다.");
+    response.put("fcmToken", fcmToken);
+
+    return ResponseEntity.ok(response);
+  }
+
+  @PatchMapping("/{notificationId}/read")
+  @Operation(
+      summary = "단일 알림 읽음 처리",
+      description = "특정 알림의 상태를 '읽음(isRead=true)'으로 변경합니다. 사용자가 알림 목록에서 특정 알림을 클릭했을 때 호출합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "읽음 처리 성공"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 알림 ID")
+  })
+  public ResponseEntity<Map<String, String>> markAsRead(
+      @Parameter(description = "읽음 처리할 알림 ID", example = "10")
+      @PathVariable Long notificationId,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    notificationService.markAsRead(notificationId);
+
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "알림을 읽음으로 처리했습니다.");
+
+    return ResponseEntity.ok(response);
+  }
+
+  @PatchMapping("/read-all")
+  @Operation(
+      summary = "모든 알림 일괄 읽음 처리",
+      description = "현재 사용자의 '읽지 않은 모든 알림'을 한 번에 '읽음' 상태로 변경합니다. (예: '모두 읽음' 버튼 클릭 시)"
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "일괄 읽음 처리 성공")
+  })
+  public ResponseEntity<Map<String, String>> markAllAsRead(
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    notificationService.markAllAsRead(principal.getUser().getId());
+
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "모든 알림을 읽음으로 처리했습니다.");
+
+    return ResponseEntity.ok(response);
+  }
+
+  @DeleteMapping("/{notificationId}")
+  @Operation(
+      summary = "단일 알림 삭제",
+      description = "특정 알림 내역을 사용자의 알림함에서 삭제합니다. (참고: 2주가 지난 알림은 서버에서 스케줄러에 의해 자동 삭제됩니다.)"
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "알림 삭제 성공"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 알림 ID")
+  })
+  public ResponseEntity<Map<String, String>> deleteNotification(
+      @Parameter(description = "삭제할 알림 ID", example = "10")
+      @PathVariable Long notificationId,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "알림을 삭제했습니다.");
+
+    return ResponseEntity.ok(response);
+  }
+
+  @PostMapping("/test-send")
+  @Operation(
+      summary = "FCM 푸시 알림 발송 테스트 (개발/QA용)",
+      description = "현재 로그인한 사용자 본인의 기기로 테스트 푸시 알림(케어 요청 타입)을 발송합니다. 비동기로 처리되며, 사전에 FCM 토큰이 등록되어 있어야 실제 기기로 알림이 수신됩니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "푸시 발송 요청 성공")
+  })
+  public ResponseEntity<Map<String, String>> testSendPush(
+      @AuthenticationPrincipal CustomPrincipal principal) {
+
+    NotificationType testType = NotificationType.CARE_REQUEST;
+
+    notificationService.sendNotification(
+        principal.getUser().getId(),
+        testType,
+        testType.getLabel(),
+        testType.getDefaultMessage(),
+        "test-care-id-999",
+        "CARE"
+    );
+
+    Map<String, String> response = new HashMap<>();
+    response.put("message", "FCM 푸시 전송이 백그라운드(Async)로 요청되었습니다.");
+    response.put("type", testType.name());
+
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/dto/response/NotificationBadgeResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/dto/response/NotificationBadgeResponse.java
@@ -1,0 +1,34 @@
+package com.newleaseonlife.SafeDogBe.domain.notification.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "알림 배지 응답 - 헤더에 표시할 미확인 알림 개수")
+public class NotificationBadgeResponse {
+
+  @Schema(description = "읽지 않은 알림 개수", example = "3")
+  private Long unreadCount;
+
+  @Schema(description = "알림이 있는지 여부", example = "true")
+  private Boolean hasUnread;
+
+  /**
+   * 미확인 알림 개수로부터 배지 응답을 생성합니다.
+   *
+   * @param unreadCount 읽지 않은 알림 개수
+   * @return 배지 응답
+   */
+  public static NotificationBadgeResponse from(Long unreadCount) {
+    return NotificationBadgeResponse.builder()
+        .unreadCount(unreadCount)
+        .hasUnread(unreadCount > 0)
+        .build();
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,64 @@
+package com.newleaseonlife.SafeDogBe.domain.notification.dto.response;
+
+import com.newleaseonlife.SafeDogBe.domain.notification.entity.Notification;
+import com.newleaseonlife.SafeDogBe.domain.notification.entity.enums.NotificationType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "알림 응답")
+public class NotificationResponse {
+
+  @Schema(description = "알림 ID", example = "1")
+  private Long id;
+
+  @Schema(description = "알림 타입", example = "CARE_REQUEST")
+  private NotificationType type;
+
+  @Schema(description = "알림 제목", example = "케어 요청")
+  private String title;
+
+  @Schema(description = "알림 내용", example = "점심 식사를 요청했어요")
+  private String body;
+
+  @Schema(description = "관련 ID (Pet/Care/PetNote)", example = "123")
+  private String relatedId;
+
+  @Schema(description = "관련 타입", example = "PET_ID")
+  private String relatedType;
+
+  @Schema(description = "읽음 여부", example = "false")
+  private Boolean isRead;
+
+  @Schema(description = "생성 시간")
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  private LocalDateTime createdAt;
+
+  /**
+   * Notification 엔티티에서 Response로 변환합니다.
+   *
+   * @param notification 알림 엔티티
+   * @return 알림 응답
+   */
+  public static NotificationResponse from(Notification notification) {
+    return NotificationResponse.builder()
+        .id(notification.getId())
+        .type(notification.getType())
+        .title(notification.getTitle())
+        .body(notification.getBody())
+        .relatedId(notification.getRelatedId())
+        .relatedType(notification.getRelatedType())
+        .isRead(notification.getIsRead())
+        .createdAt(notification.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/entity/Notification.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/entity/Notification.java
@@ -1,0 +1,88 @@
+package com.newleaseonlife.SafeDogBe.domain.notification.entity;
+
+import com.newleaseonlife.SafeDogBe.domain.notification.entity.enums.NotificationType;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import com.newleaseonlife.SafeDogBe.global.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Notification extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private NotificationType type;
+
+  @Column(nullable = false)
+  private String title;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String body;
+
+  // 관련된 Pet/Care/PetNote ID
+  @Column(name = "related_id")
+  private String relatedId;
+
+  // 관련된 타입 (PET_ID, CARE_ID, PETNOTE_ID)
+  @Column(name = "related_type")
+  private String relatedType;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private Boolean isRead = false;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private LocalDateTime createdAt = LocalDateTime.now();
+
+  /**
+   * 알림을 읽음 처리합니다.
+   */
+  public void markAsRead() {
+    this.isRead = true;
+  }
+
+  /**
+   * 알림을 읽지 않음으로 처리합니다.
+   */
+  public void markAsUnread() {
+    this.isRead = false;
+  }
+
+  /**
+   * 알림이 2주 이상 된 것인지 확인합니다.
+   *
+   * @return 2주 이상 된 경우 true
+   */
+  public boolean isOlderThanTwoWeeks() {
+    return LocalDateTime.now().isAfter(createdAt.plusWeeks(2));
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/entity/enums/NotificationType.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/entity/enums/NotificationType.java
@@ -1,0 +1,31 @@
+package com.newleaseonlife.SafeDogBe.domain.notification.entity.enums;
+
+import lombok.Getter;
+
+/**
+ * 알림 타입 열거형
+ * 2026.03 기획서 기반
+ */
+@Getter
+public enum NotificationType {
+  CARE_REQUEST("케어 요청", "반려동물 케어를 요청했어요"),
+  CARE_COMPLETED("케어 완료", "반려동물 케어가 완료되었어요"),
+  PET_ADDED("반려동물 추가", "새로운 반려동물이 추가되었어요"),
+  PET_UPDATED("반려동물 정보 수정", "반려동물 정보가 수정되었어요"),
+  PET_DELETED("반려동물 삭제", "반려동물이 삭제되었어요"),
+  PET_INVITE("반려동물 공유 초대", "반려동물 관리에 초대받았어요"),
+  GUARDIAN_ADDED("보호자 추가", "새로운 보호자가 추가되었어요"),
+  ADMIN_CHANGED("관리자 변경", "관리자 권한이 변경되었어요"),
+  PETNOTE_CREATED("반려노트 등록", "새로운 반려노트가 등록되었어요"),
+  PETNOTE_UPDATED("반려노트 수정", "반려노트가 수정되었어요"),
+  MEMO_ADDED("메모 추가", "새로운 메모가 추가되었어요"),
+  SYSTEM("시스템 알림", "시스템 알림입니다");
+
+  private final String label;
+  private final String defaultMessage;
+
+  NotificationType(String label, String defaultMessage) {
+    this.label = label;
+    this.defaultMessage = defaultMessage;
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,60 @@
+package com.newleaseonlife.SafeDogBe.domain.notification.repository;
+
+import com.newleaseonlife.SafeDogBe.domain.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+  /**
+   * 특정 사용자의 2주 이내 알림을 최신순으로 조회합니다.
+   *
+   * @param userId 사용자 ID
+   * @return 2주 이내의 알림 목록
+   */
+  @Query("SELECT n FROM Notification n " +
+      "WHERE n.user.id = :userId " +
+      "AND n.createdAt >= :twoWeeksAgo " +
+      "ORDER BY n.createdAt DESC")
+  List<Notification> findRecentNotifications(@Param("userId") Long userId,
+      @Param("twoWeeksAgo") LocalDateTime twoWeeksAgo);
+
+  /**
+   * 특정 사용자의 읽지 않은 알림 개수를 조회합니다.
+   *
+   * @param userId 사용자 ID
+   * @return 읽지 않은 알림 개수
+   */
+  long countByUserIdAndIsReadFalse(Long userId);
+
+  /**
+   * 특정 사용자의 2주 이상 된 알림을 삭제합니다.
+   *
+   * @param userId 사용자 ID
+   * @param twoWeeksAgo 2주 전 시간
+   */
+  void deleteByUserIdAndCreatedAtBefore(Long userId, LocalDateTime twoWeeksAgo);
+
+  /**
+   * 모든 2주 이상 된 알림을 삭제합니다.
+   * (스케줄러에서 사용)
+   *
+   * @param twoWeeksAgo 2주 전 시간
+   */
+  void deleteByCreatedAtBefore(LocalDateTime twoWeeksAgo);
+
+  /**
+   * 특정 사용자의 알림을 모두 읽음 처리합니다.
+   *
+   * @param userId 사용자 ID
+   */
+  @Query("UPDATE Notification n SET n.isRead = true " +
+      "WHERE n.user.id = :userId")
+  void markAllAsRead(@Param("userId") Long userId);
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/service/FCMService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/service/FCMService.java
@@ -1,0 +1,152 @@
+package com.newleaseonlife.SafeDogBe.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.Notification;
+import com.newleaseonlife.SafeDogBe.domain.notification.entity.enums.NotificationType;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FCMService {
+
+  private final FirebaseMessaging firebaseMessaging;
+  private final UserRepository userRepository;
+
+  /**
+   * FCM을 통해 푸시 알림을 전송합니다.
+   *
+   * @param user 수신자
+   * @param notificationType 알림 타입
+   * @param title 제목
+   * @param body 내용
+   * @param relatedId 관련 ID
+   */
+  @Async
+  public void sendPushNotification(User user, NotificationType notificationType,
+      String title, String body, String relatedId) {
+
+    // FCM 토큰이 없으면 전송 불가
+    if (user.getFcmToken() == null || user.getFcmToken().isEmpty()) {
+      log.warn("FCM token not found for user: {}", user.getId());
+      return;
+    }
+
+    try {
+      // 알림 생성
+      Notification notification = Notification.builder()
+          .setTitle(title)
+          .setBody(body)
+          .build();
+
+      // 데이터 페이로드 생성 (앱에서 처리할 데이터)
+      Map<String, String> data = new HashMap<>();
+      data.put("notificationType", notificationType.name());
+      data.put("relatedId", relatedId);
+      data.put("title", title);
+      data.put("body", body);
+      data.put("timestamp", String.valueOf(System.currentTimeMillis()));
+
+      // 메시지 생성
+      Message message = Message.builder()
+          .setNotification(notification)
+          .putAllData(data)
+          .setToken(user.getFcmToken())
+          .build();
+
+      // 메시지 전송
+      String response = firebaseMessaging.send(message);
+      log.info("Push notification sent successfully. Message ID: {}", response);
+
+    } catch (FirebaseMessagingException e) {
+      log.error("FCM Error Code: {}, Message: {}", e.getMessagingErrorCode(), e.getMessage());
+
+      // 토큰이 더 이상 유효하지 않은 경우 (기기에서 앱 삭제 등)
+      if (e.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED ||
+          e.getMessagingErrorCode() == MessagingErrorCode.INVALID_ARGUMENT) {
+        clearFcmToken(user);
+      }
+    }
+  }
+
+  /**
+   * 여러 사용자에게 토픽 기반 푸시 알림을 전송합니다.
+   * (예: 특정 반려동물의 모든 보호자들에게)
+   *
+   * @param topic 토픽명
+   * @param title 제목
+   * @param body 내용
+   */
+  public void sendTopicNotification(String topic, String title, String body) {
+    try {
+      Notification notification = Notification.builder()
+          .setTitle(title)
+          .setBody(body)
+          .build();
+
+      Message message = Message.builder()
+          .setNotification(notification)
+          .setTopic(topic)
+          .build();
+
+      String response = firebaseMessaging.send(message);
+      log.info("Topic notification sent successfully. Topic: {}, Message ID: {}", topic, response);
+
+    } catch (Exception e) {
+      log.error("Failed to send topic notification for topic: {}", topic, e);
+    }
+  }
+
+  /**
+   * 사용자의 FCM 토큰을 업데이트합니다.
+   *
+   * @param user 사용자
+   * @param fcmToken 새로운 FCM 토큰
+   */
+  @Transactional
+  public void updateFcmToken(User user, String fcmToken) {
+    user.updateFcmToken(fcmToken);
+    userRepository.save(user);
+    log.info("FCM token updated for user: {}", user.getId());
+  }
+
+  /**
+   * 사용자의 FCM 토큰을 삭제합니다.
+   * (토큰이 유효하지 않을 때)
+   *
+   * @param user 사용자
+   */
+  private void clearFcmToken(User user) {
+    user.updateFcmToken(null);
+    userRepository.save(user);
+    log.info("FCM token cleared for user: {}", user.getId());
+  }
+
+  /**
+   * 특정 토픽을 구독합니다.
+   * (클라이언트에서는 SDK로 호출, 서버에서 확인용)
+   *
+   * @param tokens FCM 토큰 리스트
+   * @param topic 토픽명
+   */
+  public void subscribeToTopic(java.util.List<String> tokens, String topic) {
+    try {
+      firebaseMessaging.subscribeToTopic(tokens, topic);
+      log.info("Tokens subscribed to topic: {}", topic);
+    } catch (Exception e) {
+      log.error("Failed to subscribe tokens to topic: {}", topic, e);
+    }
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/notification/service/NotificationService.java
@@ -1,0 +1,142 @@
+package com.newleaseonlife.SafeDogBe.domain.notification.service;
+
+import com.newleaseonlife.SafeDogBe.domain.notification.dto.response.NotificationBadgeResponse;
+import com.newleaseonlife.SafeDogBe.domain.notification.dto.response.NotificationResponse;
+import com.newleaseonlife.SafeDogBe.domain.notification.entity.Notification;
+import com.newleaseonlife.SafeDogBe.domain.notification.entity.enums.NotificationType;
+import com.newleaseonlife.SafeDogBe.domain.notification.repository.NotificationRepository;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.UserErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+  private final UserRepository userRepository;
+  private final FCMService fcmService;
+
+  /**
+   * 특정 사용자에게 알림을 전송합니다.
+   * 알림을 저장하고 FCM으로 푸시 알림을 전송합니다.
+   *
+   * @param userId 사용자 ID
+   * @param type 알림 타입
+   * @param title 알림 제목
+   * @param body 알림 내용
+   * @param relatedId 관련 ID
+   * @param relatedType 관련 타입
+   */
+  public void sendNotification(Long userId, NotificationType type, String title,
+      String body, String relatedId, String relatedType) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+    // 1. 알림 데이터 저장
+    Notification notification = Notification.builder()
+        .user(user)
+        .type(type)
+        .title(title)
+        .body(body)
+        .relatedId(relatedId)
+        .relatedType(relatedType)
+        .isRead(false)
+        .createdAt(LocalDateTime.now())
+        .build();
+
+    notificationRepository.save(notification);
+
+    // 2. FCM 푸시 알림 전송
+    fcmService.sendPushNotification(user, type, title, body, relatedId);
+
+    // FCM을 통해 푸시 알림 전송
+    log.info("Notification saved and push sent for user: {}, type: {}", userId, type);
+  }
+
+  /**
+   * 2주 이내의 사용자 알림을 조회합니다.
+   *
+   * @param userId 사용자 ID
+   * @return 알림 목록
+   */
+  @Transactional(readOnly = true)
+  public List<NotificationResponse> getRecentNotifications(Long userId) {
+    LocalDateTime twoWeeksAgo = LocalDateTime.now().minusWeeks(2);
+
+    return notificationRepository.findRecentNotifications(userId, twoWeeksAgo)
+        .stream()
+        .map(NotificationResponse::from)
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * 특정 알림을 읽음 처리합니다.
+   *
+   * @param notificationId 알림 ID
+   */
+  public void markAsRead(Long notificationId) {
+    Notification notification = notificationRepository.findById(notificationId)
+        .orElseThrow(() -> new BusinessException(
+            com.newleaseonlife.SafeDogBe.global.error.domain.CommonErrorCode.BAD_REQUEST));
+
+    notification.markAsRead();
+    notificationRepository.save(notification);
+  }
+
+  /**
+   * 모든 알림을 읽음 처리합니다.
+   *
+   * @param userId 사용자 ID
+   */
+  public void markAllAsRead(Long userId) {
+    notificationRepository.markAllAsRead(userId);
+  }
+
+  /**
+   * 사용자의 읽지 않은 알림 개수를 조회합니다.
+   *
+   * @param userId 사용자 ID
+   * @return 배지 응답
+   */
+  @Transactional(readOnly = true)
+  public NotificationBadgeResponse getBadgeCount(Long userId) {
+    long unreadCount = notificationRepository.countByUserIdAndIsReadFalse(userId);
+    return NotificationBadgeResponse.from(unreadCount);
+  }
+
+  /**
+   * 특정 사용자의 2주 이상 된 알림을 삭제합니다.
+   * (내부적으로 호출, 직접 API로는 노출하지 않음)
+   *
+   * @param userId 사용자 ID
+   */
+  public void deleteOldNotifications(Long userId) {
+    LocalDateTime twoWeeksAgo = LocalDateTime.now().minusWeeks(2);
+    notificationRepository.deleteByUserIdAndCreatedAtBefore(userId, twoWeeksAgo);
+    log.info("Old notifications deleted for user: {}", userId);
+  }
+
+  /**
+   * 모든 사용자의 2주 이상 된 알림을 삭제합니다.
+   * 매일 자정에 자동 실행됩니다.
+   */
+  @Scheduled(cron = "0 0 0 * * *")  // 매일 자정
+  public void deleteAllOldNotifications() {
+    LocalDateTime twoWeeksAgo = LocalDateTime.now().minusWeeks(2);
+    notificationRepository.deleteByCreatedAtBefore(twoWeeksAgo);
+    log.info("Old notifications deleted for all users");
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/controller/PetController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/controller/PetController.java
@@ -1,5 +1,8 @@
 package com.newleaseonlife.SafeDogBe.domain.pet.controller;
 
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.CommonErrorCode;
+import com.newleaseonlife.SafeDogBe.global.error.domain.FormValidationCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -80,9 +83,27 @@ public class PetController {
             @AuthenticationPrincipal CustomPrincipal principal,
             @PathVariable Long petId,
             @Valid @RequestBody PetUpdateRequest request) {
-        log.info("[PetController] 반려동물 수정 petId={}, userId={}", petId, principal.getUser().getId());
+
+        // 1. 권한 확인 (관리자 여부)
+        if (!petService.isAdminOfPet(petId, principal.getUser().getId())) {
+            throw new BusinessException(CommonErrorCode.NO_PERMISSION);
+        }
+
+        // 2. 입력값 검증
+        validatePetUpdateRequest(request);
+
         PetResponse response = petService.update(petId, principal.getUser().getId(), request);
         return ResponseEntity.ok(response);
+    }
+
+    private void validatePetUpdateRequest(PetUpdateRequest request) {
+        if (request.getName() == null || request.getName().trim().isEmpty()) {
+            throw new BusinessException(FormValidationCode.PET_NAME_REQUIRED);
+        }
+
+        if (request.getBirthDate() == null) {
+            throw new BusinessException(FormValidationCode.PET_BIRTH_REQUIRED);
+        }
     }
 
     @Operation(summary = "반려동물 삭제", description = "소유자만 가능. 보호자 연결(pet_guardian) 함께 삭제")

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/service/PetService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/service/PetService.java
@@ -13,6 +13,7 @@ import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.PetGuardian;
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetDisease;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetGuardianRole;
 import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetGuardianRepository;
 import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetRepository;
 import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
@@ -30,10 +31,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-/** 3월 18일 수정
- * ✅ 수정: create() — 신규 필드(weight, registrationNumber 등) 반영
- * ✅ 수정: update() — 신규 필드 반영, diseases 수정 지원
- * ✅ 수정: createDefaultCareTemplates() — PetDisease.defaultCheckItems() 기반 DISEASE_CARE 템플릿 생성
+/**
+ * 3월 18일 수정 ✅ 수정: create() — 신규 필드(weight, registrationNumber 등) 반영 ✅ 수정: update() — 신규 필드 반영,
+ * diseases 수정 지원 ✅ 수정: createDefaultCareTemplates() — PetDisease.defaultCheckItems() 기반
+ * DISEASE_CARE 템플릿 생성
  */
 @Slf4j
 @Service
@@ -41,149 +42,189 @@ import java.util.Set;
 @Transactional(readOnly = true)
 public class PetService {
 
-    private final PetRepository petRepository;
-    private final PetGuardianRepository petGuardianRepository;
-    private final UserRepository userRepository;
-    private final CareTemplateRepository careTemplateRepository;
-    private final PetConverter petConverter;
+  private final PetRepository petRepository;
+  private final PetGuardianRepository petGuardianRepository;
+  private final UserRepository userRepository;
+  private final CareTemplateRepository careTemplateRepository;
+  private final PetConverter petConverter;
 
-    public List<PetResponse> findMyPets(Long userId) {
-        return petConverter.toResponseList(
-            petRepository.findAllByUserIdOrderByCreatedAtDesc(userId));
+  public List<PetResponse> findMyPets(Long userId) {
+    return petConverter.toResponseList(
+        petRepository.findAllByUserIdOrderByCreatedAtDesc(userId));
+  }
+
+  public PetResponse findById(Long petId, Long userId) {
+    return petConverter.toResponse(getPetAsOwnerOrThrow(petId, userId));
+  }
+
+  /**
+   * 사용자가 반려동물의 관리자인지 확인합니다.
+   *
+   * @param petId  반려동물 ID
+   * @param userId 사용자 ID
+   * @return 관리자이면 true, 아니면 false
+   */
+  public boolean isAdminOfPet(Long petId, Long userId) {
+    return petGuardianRepository.findByPetIdAndUserId(petId, userId)
+        .map(guardian -> guardian.getRole() == PetGuardianRole.OWNER)
+        .orElse(false);
+  }
+
+  /**
+   * 사용자가 반려동물에 대한 접근 권한이 있는지 확인합니다.
+   *
+   * @param petId  반려동물 ID
+   * @param userId 사용자 ID
+   * @return 접근 권한이 있으면 true
+   */
+  public boolean hasAccessToPet(Long petId, Long userId) {
+    return petGuardianRepository.findByPetIdAndUserId(petId, userId)
+        .isPresent();
+  }
+
+  @Transactional
+  public PetResponse create(Long userId, PetCreateRequest req) {
+    log.info("[PetService] create userId={}, name={}", userId, req.getName());
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+    Set<PetDisease> diseases = req.getDiseases() != null ? req.getDiseases() : Set.of();
+
+    Pet pet = Pet.builder()
+        .user(user)
+        .name(req.getName())
+        .species(req.getSpecies())
+        .breed(req.getBreed())
+        .birthDate(req.getBirthDate())
+        .isBirthDateUnknown(req.isBirthDateUnknown())
+        .gender(req.getGender())
+        .isNeutered(req.getIsNeutered() != null && req.getIsNeutered())
+        .weight(req.getWeight())
+        .isWeightUnknown(req.isWeightUnknown())
+        .registrationNumber(req.getRegistrationNumber())
+        .hasAllergy(req.getHasAllergy())
+        .allergyDescription(req.getAllergyDescription())
+        .profileImageUrl(req.getProfileImageUrl())
+        .diseases(diseases)
+        .build();
+    petRepository.save(pet);
+
+    // 생성자를 반려동물의 메인 보호자(OWNER)로 자동 등록하는 필수 로직 추가
+    PetGuardian guardian = PetGuardian.builder()
+        .user(user)
+        .pet(pet)
+        .role(PetGuardianRole.OWNER)
+        .build();
+    petGuardianRepository.save(guardian);
+
+    // 질병별 기본 DISEASE_CARE 케어 템플릿 자동 생성
+    if (!diseases.isEmpty()) {
+      createDefaultCareTemplates(pet, diseases);
     }
 
-    public PetResponse findById(Long petId, Long userId) {
-        return petConverter.toResponse(getPetAsOwnerOrThrow(petId, userId));
+    log.info("[PetService] create 완료 petId={}", pet.getId());
+    return petConverter.toResponse(pet);
+  }
+
+  @Transactional
+  public PetResponse update(Long petId, Long userId, PetUpdateRequest req) {
+    log.info("[PetService] update petId={}, userId={}", petId, userId);
+    // 권한(isAdminOfPet)은 Controller에서 이미 검증되었으므로, 불필요한 최초 생성자(user_id) 검증을 제거합니다.
+    Pet pet = petRepository.findById(petId)
+        .orElseThrow(() -> new BusinessException(PetErrorCode.PET_NOT_FOUND));
+
+    pet.update(
+        req.getName(), req.getSpecies(), req.getBreed(),
+        req.getBirthDate(), req.getIsBirthDateUnknown(),
+        req.getGender(), req.getIsNeutered(),
+        req.getWeight(), req.getIsWeightUnknown(),
+        req.getRegistrationNumber(),
+        req.getHasAllergy(), req.getAllergyDescription(),
+        req.getProfileImageUrl()
+    );
+
+    if (req.getDiseases() != null) {
+      pet.updateDiseases(req.getDiseases());
     }
 
-    @Transactional
-    public PetResponse create(Long userId, PetCreateRequest req) {
-        log.info("[PetService] create userId={}, name={}", userId, req.getName());
-        User user = userRepository.findById(userId)
-            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    return petConverter.toResponse(pet);
+  }
 
-        Set<PetDisease> diseases = req.getDiseases() != null ? req.getDiseases() : Set.of();
+  @Transactional
+  public void delete(Long petId, Long userId) {
+    petRepository.delete(getPetAsOwnerOrThrow(petId, userId));
+  }
 
-        Pet pet = Pet.builder()
-            .user(user)
-            .name(req.getName())
-            .species(req.getSpecies())
-            .breed(req.getBreed())
-            .birthDate(req.getBirthDate())
-            .isBirthDateUnknown(req.isBirthDateUnknown())
-            .gender(req.getGender())
-            .isNeutered(req.getIsNeutered() != null && req.getIsNeutered())
-            .weight(req.getWeight())
-            .isWeightUnknown(req.isWeightUnknown())
-            .registrationNumber(req.getRegistrationNumber())
-            .hasAllergy(req.getHasAllergy())
-            .allergyDescription(req.getAllergyDescription())
-            .profileImageUrl(req.getProfileImageUrl())
-            .diseases(diseases)
-            .build();
-        petRepository.save(pet);
+  public List<PetGuardianResponse> getGuardians(Long petId, Long userId) {
+    Pet pet = getPetAsOwnerOrThrow(petId, userId);
+    return petConverter.toGuardianResponseList(
+        petGuardianRepository.findByPetIdOrderByIdAsc(pet.getId()));
+  }
 
-        // 질병별 기본 DISEASE_CARE 케어 템플릿 자동 생성
-        if (!diseases.isEmpty()) {
-            createDefaultCareTemplates(pet, diseases);
-        }
+  @Transactional
+  public PetGuardianResponse addGuardian(Long petId, Long ownerUserId, GuardianAddRequest req) {
+    Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
+    User targetUser = userRepository.findById(req.getUserId())
+        .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        log.info("[PetService] create 완료 petId={}", pet.getId());
-        return petConverter.toResponse(pet);
+    if (petGuardianRepository.existsByPetIdAndUserId(pet.getId(), req.getUserId())) {
+      throw new BusinessException(PetErrorCode.PET_GUARDIAN_ALREADY_EXISTS);
     }
 
-    @Transactional
-    public PetResponse update(Long petId, Long userId, PetUpdateRequest req) {
-        log.info("[PetService] update petId={}, userId={}", petId, userId);
-        Pet pet = getPetAsOwnerOrThrow(petId, userId);
+    PetGuardian guardian = PetGuardian.builder()
+        .user(targetUser).pet(pet).role(req.getRole()).build();
+    return petConverter.toGuardianResponse(petGuardianRepository.save(guardian));
+  }
 
-        pet.update(
-            req.getName(), req.getSpecies(), req.getBreed(),
-            req.getBirthDate(), req.getIsBirthDateUnknown(),
-            req.getGender(), req.getIsNeutered(),
-            req.getWeight(), req.getIsWeightUnknown(),
-            req.getRegistrationNumber(),
-            req.getHasAllergy(), req.getAllergyDescription(),
-            req.getProfileImageUrl()
-        );
+  /**
+   * 보호자 제거. 소유자만 가능
+   */
+  @Transactional
+  public void removeGuardian(Long petId, Long ownerUserId, Long guardianUserId) {
+    log.info("[PetService] removeGuardian petId={}, ownerUserId={}, guardianUserId={}",
+        petId, ownerUserId, guardianUserId);
+    Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
+    PetGuardian guardian = petGuardianRepository.findByPetIdAndUserId(pet.getId(), guardianUserId)
+        .orElseThrow(() -> new BusinessException(PetErrorCode.PET_GUARDIAN_NOT_FOUND));
 
-        // 질병 목록 수정 시 업데이트
-        if (req.getDiseases() != null) {
-            pet.updateDiseases(req.getDiseases());
-        }
+    // ✅ [수정] Repository에서 직접 삭제
+    petGuardianRepository.delete(guardian);
+    log.info("[PetService] removeGuardian 완료 guardianId={}", guardian.getId());
+  }
 
-        return petConverter.toResponse(pet);
+  /**
+   * 질병별 기본 DISEASE_CARE 케어 템플릿 생성.
+   * <p>
+   * ✅ 변경: 기존 MEDICINE/HOSPITAL 타입 → DISEASE_CARE 타입 ✅ 변경: defaultTemplates() → defaultCheckItems()
+   * 기반으로 각 체크 항목을 개별 CareTemplate으로 생성
+   */
+  private void createDefaultCareTemplates(Pet pet, Set<PetDisease> diseases) {
+    List<CareTemplate> templates = new ArrayList<>();
+    for (PetDisease disease : diseases) {
+      for (String checkItem : disease.getDefaultCheckItems()) {
+        templates.add(CareTemplate.builder()
+            .pet(pet)
+            .careType(CareType.DISEASE_CARE)
+            .title("[" + disease.getDescription() + "] " + checkItem)
+            // 주기 미설정 → 매일 생성
+            .build());
+      }
+    }
+    careTemplateRepository.saveAll(templates);
+    log.info("[PetService] 질병 기반 CareTemplate {}개 자동 생성 petId={}", templates.size(), pet.getId());
+  }
+
+  private Pet getPetAsOwnerOrThrow(Long petId, Long userId) {
+    // 1. PetGuardian 테이블을 조회하여 해당 유저가 이 반려동물의 권한이 있는지 확인
+    PetGuardian guardian = petGuardianRepository.findByPetIdAndUserId(petId, userId)
+        .orElseThrow(() -> new BusinessException(PetErrorCode.PET_ACCESS_DENIED));
+
+    // 2. 권한이 OWNER인지 확인 (선택적: ADMIN이나 READ_ONLY 등 세부 권한이 있다면 분기 처리)
+    if (guardian.getRole() != PetGuardianRole.OWNER) {
+      throw new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
     }
 
-    @Transactional
-    public void delete(Long petId, Long userId) {
-        petRepository.delete(getPetAsOwnerOrThrow(petId, userId));
-    }
-
-    public List<PetGuardianResponse> getGuardians(Long petId, Long userId) {
-        Pet pet = getPetAsOwnerOrThrow(petId, userId);
-        return petConverter.toGuardianResponseList(
-            petGuardianRepository.findByPetIdOrderByIdAsc(pet.getId()));
-    }
-
-    @Transactional
-    public PetGuardianResponse addGuardian(Long petId, Long ownerUserId, GuardianAddRequest req) {
-        Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
-        User targetUser = userRepository.findById(req.getUserId())
-            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
-
-        if (petGuardianRepository.existsByPetIdAndUserId(pet.getId(), req.getUserId())) {
-            throw new BusinessException(PetErrorCode.PET_GUARDIAN_ALREADY_EXISTS);
-        }
-
-        PetGuardian guardian = PetGuardian.builder()
-            .user(targetUser).pet(pet).role(req.getRole()).build();
-        return petConverter.toGuardianResponse(petGuardianRepository.save(guardian));
-    }
-
-    /** 보호자 제거. 소유자만 가능 */
-    @Transactional
-    public void removeGuardian(Long petId, Long ownerUserId, Long guardianUserId) {
-        log.info("[PetService] removeGuardian petId={}, ownerUserId={}, guardianUserId={}",
-            petId, ownerUserId, guardianUserId);
-        Pet pet = getPetAsOwnerOrThrow(petId, ownerUserId);
-        PetGuardian guardian = petGuardianRepository.findByPetIdAndUserId(pet.getId(), guardianUserId)
-            .orElseThrow(() -> new BusinessException(PetErrorCode.PET_GUARDIAN_NOT_FOUND));
-
-        // ✅ [수정] Repository에서 직접 삭제
-        petGuardianRepository.delete(guardian);
-        log.info("[PetService] removeGuardian 완료 guardianId={}", guardian.getId());
-    }
-
-    /**
-     * 질병별 기본 DISEASE_CARE 케어 템플릿 생성.
-     *
-     * ✅ 변경: 기존 MEDICINE/HOSPITAL 타입 → DISEASE_CARE 타입
-     * ✅ 변경: defaultTemplates() → defaultCheckItems() 기반으로 각 체크 항목을 개별 CareTemplate으로 생성
-     */
-    private void createDefaultCareTemplates(Pet pet, Set<PetDisease> diseases) {
-        List<CareTemplate> templates = new ArrayList<>();
-        for (PetDisease disease : diseases) {
-            for (String checkItem : disease.getDefaultCheckItems()) {
-                templates.add(CareTemplate.builder()
-                    .pet(pet)
-                    .careType(CareType.DISEASE_CARE)
-                    .title("[" + disease.getDescription() + "] " + checkItem)
-                    // 주기 미설정 → 매일 생성
-                    .build());
-            }
-        }
-        careTemplateRepository.saveAll(templates);
-        log.info("[PetService] 질병 기반 CareTemplate {}개 자동 생성 petId={}", templates.size(), pet.getId());
-    }
-
-    private Pet getPetAsOwnerOrThrow(Long petId, Long userId) {
-        return petRepository.findByIdAndUserId(petId, userId)
-            .orElseThrow(() -> {
-                if (petRepository.findById(petId).isEmpty()) {
-                    return new BusinessException(PetErrorCode.PET_NOT_FOUND);
-                }
-                return new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
-            });
-    }
+    // 3. 검증이 끝났으므로 Pet 객체를 반환
+    return guardian.getPet();
+  }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/controller/PetNoteController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/controller/PetNoteController.java
@@ -1,13 +1,29 @@
+// domain/petnote/controller/PetNoteController.java
 package com.newleaseonlife.SafeDogBe.domain.petnote.controller;
 
+import com.newleaseonlife.SafeDogBe.domain.pet.service.PetService;
 import com.newleaseonlife.SafeDogBe.domain.petnote.dto.request.PetNoteCreateRequest;
 import com.newleaseonlife.SafeDogBe.domain.petnote.dto.request.PetNoteUpdateRequest;
 import com.newleaseonlife.SafeDogBe.domain.petnote.dto.response.PetNoteResponse;
 import com.newleaseonlife.SafeDogBe.domain.petnote.service.PetNoteService;
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.CommonErrorCode;
 import com.newleaseonlife.SafeDogBe.global.security.CustomPrincipal;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -16,23 +32,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDate;
-import java.util.List;
-
-/**
- * 반려노트(PetNote) API. CRUD 및 날짜별 조회.
- * 소유권 검증은 서비스 계층에서 수행(해당 Pet의 소유자만 조회·생성·수정·삭제 가능).
- */
+@Tag(name = "PetNote", description = "반려노트(기록장) CRUD 및 날짜별 조회 API")
 @Slf4j
 @Validated
 @RestController
@@ -40,69 +42,150 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PetNoteController {
 
-    private final PetNoteService petNoteService;
+  private final PetNoteService petNoteService;
+  private final PetService petService;
 
-    /** 특정 반려동물의 노트 목록 조회 (날짜 최신순) */
-    @GetMapping
-    public ResponseEntity<List<PetNoteResponse>> getNotesByPetId(
-            @RequestParam Long petId,
-            @AuthenticationPrincipal CustomPrincipal principal) {
-        log.info("[PetNoteController] getNotesByPetId petId={}, userId={}", petId, principal.getUser().getId());
-        List<PetNoteResponse> response = petNoteService.findByPetId(petId, principal.getUser().getId());
-        return ResponseEntity.ok(response);
+  @Operation(
+      summary = "특정 반려동물의 전체 반려노트 조회",
+      description = "해당 반려동물의 모든 반려노트 목록을 최신순으로 조회합니다. 데이터가 없을 경우 안내 메시지가 포함된 객체를 반환합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공",
+          content = @Content(mediaType = "application/json", examples = {
+              @ExampleObject(name = "데이터가 있는 경우", value = "[{\"id\": 1, \"content\": \"오늘 병원 다녀옴\"}]"),
+              @ExampleObject(name = "데이터가 없는 경우", value = "{\"message\": \"등록된 반려노트가 없습니다.\", \"petId\": 1, \"notes\": []}")
+          })
+      ),
+      @ApiResponse(responseCode = "403", description = "해당 반려동물에 대한 접근 권한(소유권)이 없음", content = @Content),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 반려동물 ID", content = @Content)
+  })
+  @GetMapping
+  public ResponseEntity<Object> getNotesByPetId(
+      @Parameter(description = "조회할 대상 반려동물의 ID", example = "1")
+      @RequestParam Long petId,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+    log.info("[PetNoteController] getNotesByPetId petId={}, userId={}", petId,
+        principal.getUser().getId());
+    List<PetNoteResponse> response = petNoteService.findByPetId(petId, principal.getUser().getId());
+
+    if (response == null || response.isEmpty()) {
+      Map<String, Object> emptyResponse = new HashMap<>();
+      emptyResponse.put("message", "등록된 반려노트가 없습니다.");
+      emptyResponse.put("petId", petId);
+      emptyResponse.put("notes", response);
+      return ResponseEntity.ok(emptyResponse);
     }
 
-    /** 특정 반려동물의 특정 날짜 노트 조회 (날짜별 조회) */
-    @GetMapping("/by-date")
-    public ResponseEntity<List<PetNoteResponse>> getNotesByPetIdAndDate(
-            @RequestParam Long petId,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate noteDate,
-            @AuthenticationPrincipal CustomPrincipal principal) {
-        log.info("[PetNoteController] getNotesByPetIdAndDate petId={}, noteDate={}, userId={}",
-                petId, noteDate, principal.getUser().getId());
-        List<PetNoteResponse> response = petNoteService.findByPetIdAndDate(
-                petId, noteDate, principal.getUser().getId());
-        return ResponseEntity.ok(response);
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(
+      summary = "특정 날짜의 반려노트 조회",
+      description = "달력 등에서 특정 날짜를 선택했을 때 해당 일자의 반려노트 목록을 조회합니다. 데이터가 없을 경우 안내 메시지가 포함된 객체를 반환합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공",
+          content = @Content(mediaType = "application/json", examples = {
+              @ExampleObject(name = "데이터가 있는 경우", value = "[{\"id\": 1, \"content\": \"오늘 병원 다녀옴\"}]"),
+              @ExampleObject(name = "데이터가 없는 경우", value = "{\"message\": \"등록된 반려노트가 없습니다.\", \"petId\": 1, \"date\": \"2026-03-19\", \"notes\": []}")
+          })
+      ),
+      @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content)
+  })
+  @GetMapping("/by-date")
+  public ResponseEntity<Object> getNotesByPetIdAndDate(
+      @Parameter(description = "조회할 반려동물의 ID", example = "1")
+      @RequestParam Long petId,
+      @Parameter(description = "조회할 날짜 (yyyy-MM-dd)", example = "2026-03-19")
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate noteDate,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+    log.info("[PetNoteController] getNotesByPetIdAndDate petId={}, noteDate={}, userId={}",
+        petId, noteDate, principal.getUser().getId());
+
+    List<PetNoteResponse> response = petNoteService.findByPetIdAndDate(
+        petId, noteDate, principal.getUser().getId());
+
+    if (response == null || response.isEmpty()) {
+      Map<String, Object> emptyResponse = new HashMap<>();
+      emptyResponse.put("message", "등록된 반려노트가 없습니다.");
+      emptyResponse.put("petId", petId);
+      emptyResponse.put("date", noteDate.toString());
+      emptyResponse.put("notes", response);
+      return ResponseEntity.ok(emptyResponse);
     }
 
-    /** 반려노트 단건 조회 */
-    @GetMapping("/{noteId}")
-    public ResponseEntity<PetNoteResponse> getNote(
-            @PathVariable Long noteId,
-            @AuthenticationPrincipal CustomPrincipal principal) {
-        log.info("[PetNoteController] getNote noteId={}, userId={}", noteId, principal.getUser().getId());
-        PetNoteResponse response = petNoteService.findById(noteId, principal.getUser().getId());
-        return ResponseEntity.ok(response);
-    }
+    return ResponseEntity.ok(response);
+  }
 
-    /** 반려노트 생성 */
-    @PostMapping
-    public ResponseEntity<PetNoteResponse> createNote(
-            @Valid @RequestBody PetNoteCreateRequest request,
-            @AuthenticationPrincipal CustomPrincipal principal) {
-        log.info("[PetNoteController] createNote petId={}, userId={}", request.getPetId(), principal.getUser().getId());
-        PetNoteResponse response = petNoteService.create(request, principal.getUser().getId());
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
-    }
+  @Operation(
+      summary = "반려노트 단건 상세 조회",
+      description = "노트 ID(PK)를 통해 특정 반려노트 1개의 상세 정보를 조회합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = PetNoteResponse.class))),
+      @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 반려노트 ID", content = @Content)
+  })
+  @GetMapping("/{noteId}")
+  public ResponseEntity<PetNoteResponse> getNote(
+      @Parameter(description = "조회할 반려노트 ID", example = "10")
+      @PathVariable Long noteId,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+    PetNoteResponse response = petNoteService.findById(noteId, principal.getUser().getId());
+    return ResponseEntity.ok(response);
+  }
 
-    /** 반려노트 수정 */
-    @PatchMapping("/{noteId}")
-    public ResponseEntity<PetNoteResponse> updateNote(
-            @PathVariable Long noteId,
-            @Valid @RequestBody PetNoteUpdateRequest request,
-            @AuthenticationPrincipal CustomPrincipal principal) {
-        log.info("[PetNoteController] updateNote noteId={}, userId={}", noteId, principal.getUser().getId());
-        PetNoteResponse response = petNoteService.update(noteId, request, principal.getUser().getId());
-        return ResponseEntity.ok(response);
-    }
+  @Operation(
+      summary = "반려노트 생성(등록)",
+      description = "새로운 반려노트를 작성합니다. 요청하는 유저가 해당 반려동물의 보호자(소유권)여야만 등록이 가능합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "201", description = "생성 성공", content = @Content(schema = @Schema(implementation = PetNoteResponse.class))),
+      @ApiResponse(responseCode = "400", description = "필수 파라미터(petId, noteDate) 누락", content = @Content),
+      @ApiResponse(responseCode = "403", description = "반려동물에 대한 접근 권한 없음", content = @Content)
+  })
+  @PostMapping
+  public ResponseEntity<PetNoteResponse> createNote(
+      @Valid @RequestBody PetNoteCreateRequest request,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+    PetNoteResponse response = petNoteService.create(request, principal.getUser().getId());
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
 
-    /** 반려노트 삭제 */
-    @DeleteMapping("/{noteId}")
-    public ResponseEntity<Void> deleteNote(
-            @PathVariable Long noteId,
-            @AuthenticationPrincipal CustomPrincipal principal) {
-        log.info("[PetNoteController] deleteNote noteId={}, userId={}", noteId, principal.getUser().getId());
-        petNoteService.delete(noteId, principal.getUser().getId());
-        return ResponseEntity.noContent().build();
-    }
+  @Operation(
+      summary = "반려노트 부분 수정",
+      description = "등록된 반려노트의 내용(content)이나 기록일(noteDate)을 수정합니다. 변경을 원하지 않는 필드는 null로 보내면 기존 값이 유지됩니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(schema = @Schema(implementation = PetNoteResponse.class))),
+      @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 반려노트 ID", content = @Content)
+  })
+  @PatchMapping("/{noteId}")
+  public ResponseEntity<PetNoteResponse> updateNote(
+      @Parameter(description = "수정할 반려노트 ID", example = "10")
+      @PathVariable Long noteId,
+      @Valid @RequestBody PetNoteUpdateRequest request,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+    PetNoteResponse response = petNoteService.update(noteId, request, principal.getUser().getId());
+    return ResponseEntity.ok(response);
+  }
+
+  @Operation(
+      summary = "반려노트 삭제",
+      description = "등록된 반려노트를 삭제합니다. 해당 반려동물의 보호자만 삭제가 가능합니다."
+  )
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "삭제 성공 (반환 데이터 없음)", content = @Content),
+      @ApiResponse(responseCode = "403", description = "접근 권한 없음", content = @Content),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 반려노트 ID", content = @Content)
+  })
+  @DeleteMapping("/{noteId}")
+  public ResponseEntity<Void> deleteNote(
+      @Parameter(description = "삭제할 반려노트 ID", example = "10")
+      @PathVariable Long noteId,
+      @AuthenticationPrincipal CustomPrincipal principal) {
+    petNoteService.delete(noteId, principal.getUser().getId());
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/service/PetNoteService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/service/PetNoteService.java
@@ -9,6 +9,7 @@ import com.newleaseonlife.SafeDogBe.domain.petnote.dto.response.PetNoteResponse;
 import com.newleaseonlife.SafeDogBe.domain.petnote.entity.PetNote;
 import com.newleaseonlife.SafeDogBe.domain.petnote.repository.PetNoteRepository;
 import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.CommonErrorCode;
 import com.newleaseonlife.SafeDogBe.global.error.domain.PetErrorCode;
 import com.newleaseonlife.SafeDogBe.global.error.domain.PetNoteErrorCode;
 
@@ -37,7 +38,6 @@ public class PetNoteService {
 
     /** 반려동물별 노트 목록(날짜 최신순). 소유자만 조회 가능 */
     public List<PetNoteResponse> findByPetId(Long petId, Long userId) {
-        log.debug("[PetNoteService] findByPetId petId={}, userId={}", petId, userId);
         ensurePetOwnership(petId, userId);
         List<PetNote> notes = petNoteRepository.findAllByPet_IdOrderByNoteDateDesc(petId);
         return petNoteConverter.toResponseList(notes);
@@ -45,7 +45,6 @@ public class PetNoteService {
 
     /** 반려동물·특정일 노트 목록(날짜별 조회). 소유자만 조회 가능 */
     public List<PetNoteResponse> findByPetIdAndDate(Long petId, LocalDate noteDate, Long userId) {
-        log.debug("[PetNoteService] findByPetIdAndDate petId={}, noteDate={}, userId={}", petId, noteDate, userId);
         ensurePetOwnership(petId, userId);
         List<PetNote> notes = petNoteRepository.findAllByPet_IdAndNoteDateOrderByIdAsc(petId, noteDate);
         return petNoteConverter.toResponseList(notes);
@@ -53,7 +52,6 @@ public class PetNoteService {
 
     /** 노트 단건 조회. 해당 노트의 Pet 소유자만 가능 */
     public PetNoteResponse findById(Long noteId, Long userId) {
-        log.debug("[PetNoteService] findById noteId={}, userId={}", noteId, userId);
         PetNote note = getNoteOrThrow(noteId);
         ensurePetOwnership(note.getPetId(), userId);
         return petNoteConverter.toResponse(note);
@@ -62,29 +60,25 @@ public class PetNoteService {
     /** 반려노트 생성. request.petId에 해당하는 Pet 소유자만 가능 */
     @Transactional
     public PetNoteResponse create(PetNoteCreateRequest request, Long userId) {
-        log.info("[PetNoteService] create petId={}, noteDate={}, userId={}",
-                request.getPetId(), request.getNoteDate(), userId);
         Pet pet = petRepository.findByIdAndUserId(request.getPetId(), userId)
-                .orElseThrow(() -> {
-                    if (petRepository.findById(request.getPetId()).isEmpty()) {
-                        return new BusinessException(PetErrorCode.PET_NOT_FOUND);
-                    }
-                    return new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
-                });
+            .orElseThrow(() -> {
+                if (petRepository.findById(request.getPetId()).isEmpty()) {
+                    return new BusinessException(PetErrorCode.PET_NOT_FOUND);
+                }
+                return new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
+            });
         PetNote note = PetNote.builder()
-                .pet(pet)
-                .noteDate(request.getNoteDate())
-                .content(request.getContent())
-                .build();
+            .pet(pet)
+            .noteDate(request.getNoteDate())
+            .content(request.getContent())
+            .build();
         PetNote saved = petNoteRepository.save(note);
-        log.info("[PetNoteService] create 완료 noteId={}", saved.getId());
         return petNoteConverter.toResponse(saved);
     }
 
     /** 반려노트 수정. content·noteDate 중 전달된 값만 반영. 소유자만 가능 */
     @Transactional
     public PetNoteResponse update(Long noteId, PetNoteUpdateRequest request, Long userId) {
-        log.info("[PetNoteService] update noteId={}, userId={}", noteId, userId);
         PetNote note = getNoteOrThrow(noteId);
         ensurePetOwnership(note.getPetId(), userId);
         note.update(request.getContent(), request.getNoteDate());
@@ -94,20 +88,51 @@ public class PetNoteService {
     /** 반려노트 삭제. 해당 노트의 Pet 소유자만 가능 */
     @Transactional
     public void delete(Long noteId, Long userId) {
-        log.info("[PetNoteService] delete noteId={}, userId={}", noteId, userId);
         PetNote note = getNoteOrThrow(noteId);
         ensurePetOwnership(note.getPetId(), userId);
         petNoteRepository.delete(note);
-        log.info("[PetNoteService] delete 완료 noteId={}", noteId);
+    }
+    // ============== 컨트롤러/UI 컴포넌트용 추가 메서드 ==============
+
+    public List<PetNoteResponse> getPetNotes(Long petId) {
+        if (petRepository.findById(petId).isEmpty()) {
+            throw new BusinessException(PetErrorCode.PET_NOT_FOUND);
+        }
+        List<PetNote> notes = petNoteRepository.findAllByPet_IdOrderByNoteDateDesc(petId);
+        return petNoteConverter.toResponseList(notes);
     }
 
+    public List<PetNoteResponse> getPetNotesByDate(Long petId, LocalDate date) {
+        if (petRepository.findById(petId).isEmpty()) {
+            throw new BusinessException(PetErrorCode.PET_NOT_FOUND);
+        }
+        if (date == null) {
+            throw new BusinessException(CommonErrorCode.BAD_REQUEST, "조회할 날짜를 지정해주세요.");
+        }
+        List<PetNote> notes = petNoteRepository.findAllByPet_IdAndNoteDateOrderByIdAsc(petId, date);
+        return petNoteConverter.toResponseList(notes);
+    }
+
+    public boolean hasAccessToNote(Long noteId, Long userId) {
+        try {
+            findById(noteId, userId);
+            return true;
+        } catch (BusinessException e) {
+            return false;
+        }
+    }
+
+    public boolean belongsToPet(Long noteId, Long petId) {
+        return petNoteRepository.findById(noteId)
+            .map(note -> note.getPetId().equals(petId))
+            .orElse(false);
+    }
+
+    // ============== 내부 Helper 메서드 ==============
     /** 노트 조회. 없으면 PET_NOTE_NOT_FOUND */
     private PetNote getNoteOrThrow(Long noteId) {
         return petNoteRepository.findById(noteId)
-                .orElseThrow(() -> {
-                    log.warn("[PetNoteService] 반려노트 없음 noteId={}", noteId);
-                    return new BusinessException(PetNoteErrorCode.PET_NOTE_NOT_FOUND);
-                });
+            .orElseThrow(() -> new BusinessException(PetNoteErrorCode.PET_NOTE_NOT_FOUND));
     }
 
     /**

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/entity/User.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/user/entity/User.java
@@ -72,7 +72,6 @@ public class User {
 
     /** 생년월일 (선택) */
     private LocalDate birthDate;
-
     /** 프로필 이미지 URL. 긴 URL 대비 TEXT 사용 */
     @Column(columnDefinition = "TEXT")
     private String profileImageUrl;
@@ -118,6 +117,32 @@ public class User {
 
     /** 탈퇴 요청 시각. Soft Delete 시점 기준 30일 내 복구 가능, 1년간 기록 보관 */
     private LocalDateTime withdrawnAt;
+
+
+    //------------------FCM 관련----------------------------------
+    @Column(name = "fcm_token", length = 500)
+    private String fcmToken;
+
+    @Column(name = "last_fcm_token_update")
+    private LocalDateTime lastFcmTokenUpdate;
+
+    /**
+     * FCM 토큰 업데이트 (도메인 주도 설계 방식)
+     * @param newToken 클라이언트로부터 전달받은 새 토큰
+     */
+    public void updateFcmToken(String newToken) {
+        if (newToken == null || newToken.isBlank()) {
+            this.fcmToken = null;
+            this.lastFcmTokenUpdate = null;
+            return;
+        }
+
+        // 기존 토큰과 다를 때만 업데이트 시간 갱신 (선택 사항)
+        if (!newToken.equals(this.fcmToken)) {
+            this.fcmToken = newToken;
+            this.lastFcmTokenUpdate = LocalDateTime.now();
+        }
+    }
 
     @Builder
     public User(String email, String nickname, String name, String phone,

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/config/FirebaseConfig.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/config/FirebaseConfig.java
@@ -1,0 +1,52 @@
+package com.newleaseonlife.SafeDogBe.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+
+@Configuration
+@Slf4j
+public class FirebaseConfig {
+
+  // 파라미터 스토어의 이름을 변수로 받습니다.
+  @Value("${firebase.credentials-content}")
+  private String firebaseCredentialsContent;
+
+  @Bean
+  public FirebaseApp firebaseApp() throws IOException {
+    if (FirebaseApp.getApps().isEmpty()) {
+
+      // AWS에서 가져온 Base64 인코딩된 문자열을 바이트 배열로 디코딩
+      byte[] decodedBytes = java.util.Base64.getDecoder().decode(firebaseCredentialsContent);
+
+      // 파일 경로 대신 문자열(JSON)을 스트림으로 변환
+      InputStream credentialsStream = new ByteArrayInputStream(
+          firebaseCredentialsContent.getBytes(StandardCharsets.UTF_8)
+      );
+
+      FirebaseOptions options = FirebaseOptions.builder()
+          .setCredentials(GoogleCredentials.fromStream(credentialsStream))
+          .build();
+
+      FirebaseApp.initializeApp(options);
+      log.info("Firebase app initialized using AWS Parameter Store");
+    }
+
+    return FirebaseApp.getInstance();
+  }
+
+  @Bean
+  public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
+    return FirebaseMessaging.getInstance(firebaseApp);
+  }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/ErrorResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/ErrorResponse.java
@@ -1,25 +1,29 @@
 package com.newleaseonlife.SafeDogBe.global.error;
 
+import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 
 /** API 오류 응답 DTO. status(HTTP 상태 코드), code(비즈니스 코드), message(클라이언트 메시지). */
 @Getter
+@Builder
 public class ErrorResponse {
-
     private final int status;
-    private final int code;
+    private final Integer code;
     private final String message;
 
-    @Builder
-    public ErrorResponse(int status, int code, String message) {
-        this.status = status;
-        this.code = code;
-        this.message = message;
+    // ✅ 모니터링 및 추적을 위해 추가된 필드
+    private final String path;
+    private final LocalDateTime timestamp;
+
+    public static ErrorResponse of(int status, Integer code, String message, String path) {
+        return ErrorResponse.builder()
+            .status(status)
+            .code(code)
+            .message(message)
+            .path(path)
+            .timestamp(LocalDateTime.now()) // 에러 객체 생성 시점의 시간 자동 할당
+            .build();
     }
 
-    /** 편의 팩토리. GlobalExceptionHandler 등에서 사용. */
-    public static ErrorResponse of(int status, int code, String message) {
-        return new ErrorResponse(status, code, message);
-    }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.newleaseonlife.SafeDogBe.global.error;
 
 import com.newleaseonlife.SafeDogBe.global.error.domain.CommonErrorCode;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 
 import lombok.extern.slf4j.Slf4j;
@@ -24,84 +25,94 @@ public class GlobalExceptionHandler {
 
     /** 도메인 비즈니스 예외 (AuthErrorCode, UserErrorCode 등). */
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ErrorResponse> handleBusiness(BusinessException e) {
+    public ResponseEntity<ErrorResponse> handleBusiness(BusinessException e, HttpServletRequest request) {
         ApiCode code = e.getCode();
-        log.warn("[BusinessException] code={}, message={}", code.getCode(), e.resolvedMessage());
+        log.warn("[BusinessException] path={}, code={}, message={}", request.getRequestURI(), code.getCode(), e.resolvedMessage());
+
         return ResponseEntity
-                .status(code.getHttpStatus())
-                .body(ErrorResponse.of(
-                        code.getHttpStatus().value(),
-                        code.getCode(),
-                        e.resolvedMessage()
-                ));
+            .status(code.getHttpStatus())
+            .body(ErrorResponse.of(
+                code.getHttpStatus().value(),
+                code.getCode(),
+                e.resolvedMessage(),
+                request.getRequestURI()
+            ));
     }
 
     // @RequestBody + @Valid 검증 실패
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e, HttpServletRequest request) {
         String message = e.getBindingResult().getFieldErrors().stream()
-                .findFirst()
-                .map(err -> err.getDefaultMessage() != null ? err.getDefaultMessage() : "잘못된 요청입니다.")
-                .orElse(CommonErrorCode.BAD_REQUEST.getMessage());
-        log.warn("[ValidationException] message={}", message);
+            .findFirst()
+            .map(err -> err.getDefaultMessage() != null ? err.getDefaultMessage() : "잘못된 요청입니다.")
+            .orElse(CommonErrorCode.BAD_REQUEST.getMessage());
+
+        log.warn("[ValidationException] path={}, message={}", request.getRequestURI(), message);
         ApiCode code = CommonErrorCode.BAD_REQUEST;
+
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), code.getCode(), message));
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), code.getCode(), message, request.getRequestURI()));
     }
 
     // @Validated + @RequestParam 검증 실패 (UserController.checkNickname 등)
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException e) {
+    public ResponseEntity<ErrorResponse> handleConstraintViolation(ConstraintViolationException e, HttpServletRequest request) {
         String message = e.getConstraintViolations().stream()
-                .findFirst()
-                .map(v -> v.getMessage() != null ? v.getMessage() : "잘못된 요청입니다.")
-                .orElse(CommonErrorCode.BAD_REQUEST.getMessage());
-        log.warn("[ConstraintViolationException] message={}", message);
+            .findFirst()
+            .map(v -> v.getMessage() != null ? v.getMessage() : "잘못된 요청입니다.")
+            .orElse(CommonErrorCode.BAD_REQUEST.getMessage());
+
+        log.warn("[ConstraintViolationException] path={}, message={}", request.getRequestURI(), message);
         ApiCode code = CommonErrorCode.BAD_REQUEST;
+
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), code.getCode(), message));
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), code.getCode(), message, request.getRequestURI()));
     }
 
     // JPA 낙관적 락 충돌
     @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
-    public ResponseEntity<ErrorResponse> handleOptimisticLock(ObjectOptimisticLockingFailureException e) {
-        log.error("[OptimisticLockException] 동시 수정 충돌 발생", e);
+    public ResponseEntity<ErrorResponse> handleOptimisticLock(ObjectOptimisticLockingFailureException e, HttpServletRequest request) {
+        log.error("[OptimisticLockException] path={}, 동시 수정 충돌 발생", request.getRequestURI(), e);
         ApiCode code = CommonErrorCode.OPTIMISTIC_LOCK_CONFLICT;
+
         return ResponseEntity
-                .status(code.getHttpStatus())
-                .body(ErrorResponse.of(code.getHttpStatus().value(), code.getCode(), code.getMessage()));
+            .status(code.getHttpStatus())
+            .body(ErrorResponse.of(code.getHttpStatus().value(), code.getCode(), code.getMessage(), request.getRequestURI()));
     }
 
     // 파일 업로드 용량 초과
     @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public ResponseEntity<ErrorResponse> handleMaxUpload(MaxUploadSizeExceededException e) {
-        log.warn("[MaxUploadSizeExceededException] 파일 용량 초과");
+    public ResponseEntity<ErrorResponse> handleMaxUpload(MaxUploadSizeExceededException e, HttpServletRequest request) {
+        log.warn("[MaxUploadSizeExceededException] path={}, 파일 용량 초과", request.getRequestURI());
         ApiCode code = CommonErrorCode.FILE_SIZE_EXCEED;
+
         return ResponseEntity
-                .status(code.getHttpStatus())
-                .body(ErrorResponse.of(code.getHttpStatus().value(), code.getCode(), code.getMessage()));
+            .status(code.getHttpStatus())
+            .body(ErrorResponse.of(code.getHttpStatus().value(), code.getCode(), code.getMessage(), request.getRequestURI()));
     }
 
     // 잘못된 인자 (예: S3 파일 검증 실패 등) → 400 Bad Request
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException e) {
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException e, HttpServletRequest request) {
         String message = e.getMessage() != null ? e.getMessage() : CommonErrorCode.BAD_REQUEST.getMessage();
-        log.warn("[IllegalArgumentException] message={}", message);
+        log.warn("[IllegalArgumentException] path={}, message={}", request.getRequestURI(), message);
         ApiCode code = CommonErrorCode.BAD_REQUEST;
+
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), code.getCode(), message));
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), code.getCode(), message, request.getRequestURI()));
     }
 
     /** 그 외 미처리 예외 → 500 Server Error. */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleAny(Exception e) {
-        log.error("[UnhandledException] 예상치 못한 서버 에러", e);
+    public ResponseEntity<ErrorResponse> handleAny(Exception e, HttpServletRequest request) {
+        log.error("[UnhandledException] path={}, 예상치 못한 서버 에러", request.getRequestURI(), e);
         ApiCode code = CommonErrorCode.SERVER_ERROR;
+
         return ResponseEntity
-                .status(code.getHttpStatus())
-                .body(ErrorResponse.of(code.getHttpStatus().value(), code.getCode(), code.getMessage()));
+            .status(code.getHttpStatus())
+            .body(ErrorResponse.of(code.getHttpStatus().value(), code.getCode(), code.getMessage(), request.getRequestURI()));
     }
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/CommonErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/CommonErrorCode.java
@@ -1,23 +1,31 @@
 package com.newleaseonlife.SafeDogBe.global.error.domain;
 
 import com.newleaseonlife.SafeDogBe.global.error.ApiCode;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
 import org.springframework.http.HttpStatus;
 
-/** 공통 에러 코드. (deprecation 경고: Spring HttpStatus 등 외부 API 사용으로 인한 ADVICE 수준) */
+/** 3월 19일 수정
+ * 공통 에러 코드. (deprecation 경고: Spring HttpStatus 등 외부 API 사용으로 인한 ADVICE 수준) */
 @SuppressWarnings("deprecation")
 @AllArgsConstructor
 @Getter
 public enum CommonErrorCode implements ApiCode {
-
+    // 기존 에러 코드
     BAD_REQUEST(HttpStatus.BAD_REQUEST, 400, "잘못된 요청입니다."),
     MISSING_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, 400, "필수 헤더가 누락되었습니다."),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 에러가 발생했습니다."),
     FILE_SIZE_EXCEED(HttpStatus.PAYLOAD_TOO_LARGE, 413, "10MB 이하의 이미지만 등록 가능합니다."),
-    OPTIMISTIC_LOCK_CONFLICT(HttpStatus.CONFLICT, 409, "동시에 저장 요청이 발생했습니다.");
+    OPTIMISTIC_LOCK_CONFLICT(HttpStatus.CONFLICT, 409, "동시에 저장 요청이 발생했습니다."),
+
+    // 신규 에러 코드 (2026.03 기획서 반영)
+    NOT_LOGGED_IN(HttpStatus.UNAUTHORIZED, 401, "로그인이 필요합니다."),
+    NO_PERMISSION(HttpStatus.FORBIDDEN, 403, "관리자만 접근이 가능합니다."),
+    PET_NOT_REGISTERED(HttpStatus.BAD_REQUEST, 400, "등록된 반려동물이 없습니다."),
+    PET_NOTE_NOT_FOUND(HttpStatus.BAD_REQUEST, 400, "등록된 반려노트가 없습니다."),
+    SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 500, "저장에 실패하였습니다. 다시 시도해 주세요."),
+    CONCURRENT_EDIT_DETECTED(HttpStatus.CONFLICT, 409, "방금 다른 보호자가 체크리스트를 수정했어요. 마지막으로 수정한 체크리스트로 화면이 변경됩니다."),
+    INVALID_FORM_DATA(HttpStatus.BAD_REQUEST, 400, "필수 항목을 입력해주세요.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/FormValidationCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/FormValidationCode.java
@@ -1,0 +1,38 @@
+package com.newleaseonlife.SafeDogBe.global.error.domain;
+
+import com.newleaseonlife.SafeDogBe.global.error.ApiCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/** 3월 19일 수정
+ * 공통 에러 코드. (deprecation 경고: Spring HttpStatus 등 외부 API 사용으로 인한 ADVICE 수준) */
+@SuppressWarnings("deprecation")
+@AllArgsConstructor
+@Getter
+public enum FormValidationCode implements ApiCode {
+  // --- 폼 검증 관련 메시지 (반려동물 정보) ---
+  PET_NAME_REQUIRED(HttpStatus.BAD_REQUEST, 400, "반려견 이름은 필수 항목입니다."),
+  PET_BIRTH_REQUIRED(HttpStatus.BAD_REQUEST, 400, "생년월일은 필수 항목입니다."),
+  PET_GENDER_REQUIRED(HttpStatus.BAD_REQUEST, 400, "성별은 필수 항목입니다."),
+
+  // --- 폼 검증 관련 메시지 (체크리스트) ---
+  CHECKLIST_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, 400, "체크리스트 제목은 필수 항목입니다."),
+  CARE_ITEM_REQUIRED(HttpStatus.BAD_REQUEST, 400, "케어 항목은 최소 하나 이상 필요합니다."),
+
+  // --- 폼 검증 관련 메시지 (반려노트) ---
+  PETNOTE_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, 400, "반려노트 내용은 필수 항목입니다."),
+
+  // --- 폼 검증 관련 메시지 (사용자 정보) ---
+  USER_NAME_REQUIRED(HttpStatus.BAD_REQUEST, 400, "이름은 필수 항목입니다."),
+  USER_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, 400, "이메일은 필수 항목입니다.");
+
+  private final HttpStatus httpStatus;
+  private final Integer code;
+  private final String message;
+
+  @Override
+  public HttpStatus getHttpStatus() {
+    return this.httpStatus;
+  }
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -134,3 +134,6 @@ management:
   metrics:
     tags:
       application: SafeDogBe
+
+firebase:
+  credentials-path: ${FIREBASE_CREDENTIALS_PATH:classpath:firebase-credentials.json}


### PR DESCRIPTION
## Major Changes

### 1. Notification System (FCM)
- Notification 엔티티 및 FCMService 구현
- 배지 개수 조회 API 추가
- 2주 자동 삭제 스케줄러

### 2. Error Handling
- 공통 에러 코드 7개 확장
- 권한 확인 로직 표준화
- Form 검증 메시지 개선

### 3. Permission Management
- 반려동물 접근 권한 검증 추가
- 관리자/보호자 역할 구분
- 권한 없을 시 명확한 에러 메시지

### 4. Concurrency Control
- OptimisticLocking을 통한 동시 편집 감지
- 충돌 시 최신 데이터 강제 갱신

### 5. Data Management
- 반려노트 미등록 안내
- 체크리스트 로그 90일 자동 삭제

## 🔗 관련 이슈
> e.g. Close #이슈번호

#81 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.
