### PR TITLE
홈·마이페이지 전용 API 오류 코드 정의 및 적용

### DIFF
--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/DailyChecklistConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/converter/DailyChecklistConverter.java
@@ -30,6 +30,7 @@ public class DailyChecklistConverter {
             .completedByUserId(c.getCompletedBy() != null ? c.getCompletedBy().getId() : null)
             .completedByNickname(c.getCompletedBy() != null ? c.getCompletedBy().getNickname() : null)
             .completedByProfileImageUrl(c.getCompletedBy() != null ? c.getCompletedBy().getProfileImageUrl() : null)
+            .completedAt(c.getCompletedAt())
             .version(c.getVersion())
             .updatedAt(c.getUpdatedAt())
             .build())

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/DailyChecklistResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/dto/response/DailyChecklistResponse.java
@@ -31,6 +31,8 @@ public class DailyChecklistResponse {
   private String completedByNickname;
   /** ✅ 추가: 완료자 프로필 이미지 URL */
   private String completedByProfileImageUrl;
+  /** ✅ 추가: 완료 처리 시각 */
+  private LocalDateTime completedAt;
   private Integer version;
   private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/DailyChecklist.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/entity/DailyChecklist.java
@@ -83,6 +83,10 @@ public class DailyChecklist {
   @JoinColumn(name = "completed_by", foreignKey = @ForeignKey(name = "fk_daily_checklist_completed"))
   private User completedBy;
 
+  /** 완료 처리 시각. 완료 취소 시 null로 초기화 */
+  @Column
+  private LocalDateTime completedAt;
+
   // 백엔드 핵심: 동시성 제어를 위한 낙관적 락(Optimistic Lock)
   @Version
   @Column(nullable = false)
@@ -111,12 +115,14 @@ public class DailyChecklist {
   public void complete(User user) {
     this.isCompleted = true;
     this.completedBy = user;
+    this.completedAt = LocalDateTime.now();
   }
 
   // 비즈니스 로직 2: 체크리스트 완료 취소
   public void uncomplete() {
     this.isCompleted = false;
     this.completedBy = null;
+    this.completedAt = null;
   }
 
   // 비즈니스 로직 3: 스냅샷 내용 수정 (오늘만 특별히 내용을 바꿀 때)

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/DailyChecklistRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/care/repository/DailyChecklistRepository.java
@@ -29,4 +29,13 @@ public interface DailyChecklistRepository extends JpaRepository<DailyChecklist, 
   List<LocalDate> findDistinctDatesByPetIdAndDateBetween(@Param("petId") Long petId,
       @Param("from") LocalDate from,
       @Param("to") LocalDate to);
+
+  /** 홈 진행률: 특정 날짜의 전체 체크리스트 수 */
+  long countByPet_IdAndTargetDate(Long petId, LocalDate targetDate);
+
+  /** 홈 진행률: 특정 날짜의 완료된 체크리스트 수 */
+  long countByPet_IdAndTargetDateAndIsCompleted(Long petId, LocalDate targetDate, boolean isCompleted);
+
+  /** 홈 체크리스트 존재 여부 */
+  boolean existsByPet_IdAndTargetDate(Long petId, LocalDate targetDate);
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/controller/HomeController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/controller/HomeController.java
@@ -1,0 +1,91 @@
+package com.newleaseonlife.SafeDogBe.domain.home.controller;
+
+import com.newleaseonlife.SafeDogBe.domain.care.dto.response.DailyChecklistResponse;
+import com.newleaseonlife.SafeDogBe.domain.care.service.DailyChecklistService;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.request.SelectPetRequest;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.response.HomeChecklistResponse;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.response.HomePetListResponse;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.response.HomeResponse;
+import com.newleaseonlife.SafeDogBe.domain.home.service.HomeService;
+import com.newleaseonlife.SafeDogBe.global.security.CustomPrincipal;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/home")
+@RequiredArgsConstructor
+@Tag(name = "Home", description = "홈 화면 API")
+public class HomeController {
+
+    private final HomeService homeService;
+    private final DailyChecklistService dailyChecklistService;
+
+    @Operation(summary = "반려동물 선택 저장",
+            description = "사용자가 선택한 반려동물 ID를 서버에 저장합니다. 이후 홈 화면 조회 시 해당 반려동물이 기본값으로 사용됩니다.")
+    @PatchMapping("/selected-pet")
+    public ResponseEntity<Void> selectPet(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @Valid @RequestBody SelectPetRequest request) {
+        homeService.selectPet(principal.getUser().getId(), request.petId());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "반려동물 목록 조회",
+            description = "직접 등록한 반려동물과 공유받은 반려동물 목록을 반환합니다. 마지막 선택 반려동물 ID도 함께 포함됩니다.")
+    @GetMapping("/pets")
+    public ResponseEntity<HomePetListResponse> getPetList(
+            @AuthenticationPrincipal CustomPrincipal principal) {
+        return ResponseEntity.ok(homeService.getPetList(principal.getUser().getId()));
+    }
+
+    @Operation(summary = "홈 화면 데이터 조회",
+            description = "선택된 반려동물의 프로필, 오늘 케어 진행률, 메모 목록, 체크리스트 존재 여부를 한 번에 반환합니다.")
+    @GetMapping
+    public ResponseEntity<HomeResponse> getHome(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @RequestParam(required = false) Long petId) {
+        return ResponseEntity.ok(homeService.getHomeData(principal.getUser().getId(), petId));
+    }
+
+    @Operation(summary = "체크리스트 조회 (탭/카테고리 구분)",
+            description = "기본 케어 / 질병 케어 탭으로 구분하여 항목이 있는 카테고리만 반환합니다.")
+    @GetMapping("/checklists")
+    public ResponseEntity<HomeChecklistResponse> getChecklists(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @RequestParam Long petId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        LocalDate targetDate = date != null ? date : LocalDate.now();
+        return ResponseEntity.ok(homeService.getChecklists(principal.getUser().getId(), petId, targetDate));
+    }
+
+    @Operation(summary = "체크리스트 수행 완료 처리",
+            description = "체크박스 '예' 클릭 시 호출. 수행 시각, 수행자 정보를 저장하고 업데이트된 항목 상태를 반환합니다.")
+    @PostMapping("/checklists/{checklistId}/complete")
+    public ResponseEntity<DailyChecklistResponse> completeChecklist(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @PathVariable Long checklistId) {
+        return ResponseEntity.ok(
+                dailyChecklistService.completeChecklist(checklistId, principal.getUser().getId()));
+    }
+
+    @Operation(summary = "체크리스트 수행 취소",
+            description = "체크박스 '아니요' 클릭 시 호출. 완료 상태를 되돌립니다.")
+    @PostMapping("/checklists/{checklistId}/uncomplete")
+    public ResponseEntity<DailyChecklistResponse> uncompleteChecklist(
+            @AuthenticationPrincipal CustomPrincipal principal,
+            @PathVariable Long checklistId) {
+        return ResponseEntity.ok(
+                dailyChecklistService.uncompleteChecklist(checklistId, principal.getUser().getId()));
+    }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/request/SelectPetRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/request/SelectPetRequest.java
@@ -1,0 +1,7 @@
+package com.newleaseonlife.SafeDogBe.domain.home.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SelectPetRequest(
+        @NotNull(message = "반려동물 ID는 필수입니다.") Long petId
+) {}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomeCareProgressResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomeCareProgressResponse.java
@@ -1,0 +1,20 @@
+package com.newleaseonlife.SafeDogBe.domain.home.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 홈 화면 케어 진행률 */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HomeCareProgressResponse {
+
+    /** 오늘 요청된 전체 케어 수 */
+    private long totalCount;
+
+    /** 완료된 케어 수 */
+    private long completedCount;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomeChecklistCategoryResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomeChecklistCategoryResponse.java
@@ -1,0 +1,25 @@
+package com.newleaseonlife.SafeDogBe.domain.home.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/** 케어 타입 카테고리 단위 체크리스트 */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HomeChecklistCategoryResponse {
+
+    /** CareType enum 값 (MEAL, WALK 등) */
+    private String careType;
+
+    /** 케어 타입 한글 설명 */
+    private String careTypeDescription;
+
+    /** 해당 카테고리의 체크리스트 항목 목록 */
+    private List<HomeChecklistItemResponse> items;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomeChecklistItemResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomeChecklistItemResponse.java
@@ -1,0 +1,36 @@
+package com.newleaseonlife.SafeDogBe.domain.home.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/** 홈 체크리스트 개별 항목 */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HomeChecklistItemResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+    private boolean isCompleted;
+
+    /** 케어 템플릿이 있으면 true (스케줄러에 의해 요청된 항목) */
+    private boolean isRequested;
+
+    /** 완료 처리 시각. 완료 전이면 null */
+    private LocalDateTime completedAt;
+
+    /** 완료자 프로필 이미지 URL */
+    private String completedByProfileImageUrl;
+
+    /** 완료자 닉네임 */
+    private String completedByNickname;
+
+    /** 낙관적 락 버전 */
+    private Integer version;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomeChecklistResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomeChecklistResponse.java
@@ -1,0 +1,22 @@
+package com.newleaseonlife.SafeDogBe.domain.home.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/** 홈 체크리스트 탭 구분 응답 */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HomeChecklistResponse {
+
+    /** 기본 케어 탭 (DISEASE_CARE 제외한 모든 케어 타입) */
+    private List<HomeChecklistCategoryResponse> basicCare;
+
+    /** 질병 케어 탭 (DISEASE_CARE 전용) */
+    private List<HomeChecklistCategoryResponse> diseaseCare;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomeNoteResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomeNoteResponse.java
@@ -1,40 +1,40 @@
-package com.newleaseonlife.SafeDogBe.domain.petnote.dto.response;
+package com.newleaseonlife.SafeDogBe.domain.home.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-/**
- * 반려노트 응답. 조회·등록·수정 API 응답에 사용.
- */
+/** 홈 화면 메모 목록 항목 */
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PetNoteResponse {
+public class HomeNoteResponse {
 
-    /** 반려노트 PK */
     private Long id;
-    /** 대상 반려동물 ID */
-    private Long petId;
-    /** 기록 대상일 */
-    private LocalDate noteDate;
-    /** 메모 내용 */
     private String content;
+
     /** 작성자 ID */
     private Long writtenByUserId;
+
     /** 작성자 닉네임 */
     private String writtenByNickname;
+
     /** 작성자 프로필 이미지 URL */
     private String writtenByProfileImageUrl;
+
+    /** 작성자의 반려동물에 대한 역할 (OWNER / CAREGIVER) */
+    private String writtenByRole;
+
+    /** 전송(생성) 시각 */
+    private LocalDateTime sentAt;
+
+    /** 마지막 로그인 이후 새로 작성된 메모 여부 */
+    private boolean isNew;
+
     /** 연결된 체크리스트 ID (optional) */
     private Long linkedChecklistId;
-    /** 생성 일시 */
-    private LocalDateTime createdAt;
-    /** 수정 일시 */
-    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomePetListResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomePetListResponse.java
@@ -1,0 +1,22 @@
+package com.newleaseonlife.SafeDogBe.domain.home.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/** 홈 반려동물 목록 조회 응답 */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HomePetListResponse {
+
+    /** 마지막으로 선택한 반려동물 ID. null이면 미선택 */
+    private Long lastSelectedPetId;
+
+    /** 직접 등록 + 공유받은 반려동물 목록 (등록일 오름차순) */
+    private List<HomePetSummaryResponse> pets;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomePetProfileResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomePetProfileResponse.java
@@ -1,0 +1,21 @@
+package com.newleaseonlife.SafeDogBe.domain.home.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** 홈 화면 상단 반려동물 프로필 */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HomePetProfileResponse {
+
+    private Long id;
+    private String name;
+    private String profileImageUrl;
+
+    /** 현재 사용자의 역할 (OWNER / CAREGIVER) */
+    private String role;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomePetSummaryResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomePetSummaryResponse.java
@@ -1,0 +1,29 @@
+package com.newleaseonlife.SafeDogBe.domain.home.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/** 홈 반려동물 목록 조회 시 개별 반려동물 항목 */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HomePetSummaryResponse {
+
+    private Long id;
+    private String name;
+    private String profileImageUrl;
+    private LocalDate birthDate;
+    private boolean isBirthDateUnknown;
+    private String species;
+
+    /** OWNER: 직접 등록, SHARED: 공유받은 반려동물 */
+    private String registrationType;
+
+    /** 이 반려동물에 대한 현재 사용자의 역할 (OWNER / CAREGIVER) */
+    private String role;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomeResponse.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/dto/response/HomeResponse.java
@@ -1,0 +1,31 @@
+package com.newleaseonlife.SafeDogBe.domain.home.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/** 홈 화면 통합 데이터 응답 */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HomeResponse {
+
+    /** 반려동물 미등록 여부. true이면 FE에서 등록 유도 화면으로 분기 */
+    private boolean hasPets;
+
+    /** 선택된 반려동물 프로필 */
+    private HomePetProfileResponse petProfile;
+
+    /** 오늘 케어 진행률 */
+    private HomeCareProgressResponse careProgress;
+
+    /** 최신 메모 목록 (최신순, 최대 20건) */
+    private List<HomeNoteResponse> notes;
+
+    /** 오늘 날짜 기준 체크리스트 등록 여부 */
+    private boolean hasChecklist;
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/service/HomeService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/home/service/HomeService.java
@@ -1,0 +1,276 @@
+package com.newleaseonlife.SafeDogBe.domain.home.service;
+
+import com.newleaseonlife.SafeDogBe.domain.care.entity.DailyChecklist;
+import com.newleaseonlife.SafeDogBe.domain.care.entity.enums.CareType;
+import com.newleaseonlife.SafeDogBe.domain.care.repository.DailyChecklistRepository;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.response.HomeCareProgressResponse;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.response.HomeChecklistCategoryResponse;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.response.HomeChecklistItemResponse;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.response.HomeChecklistResponse;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.response.HomeNoteResponse;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.response.HomePetListResponse;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.response.HomePetProfileResponse;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.response.HomePetSummaryResponse;
+import com.newleaseonlife.SafeDogBe.domain.home.dto.response.HomeResponse;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.PetGuardian;
+import com.newleaseonlife.SafeDogBe.domain.pet.entity.enums.PetGuardianRole;
+import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetGuardianRepository;
+import com.newleaseonlife.SafeDogBe.domain.pet.repository.PetRepository;
+import com.newleaseonlife.SafeDogBe.domain.petnote.entity.PetNote;
+import com.newleaseonlife.SafeDogBe.domain.petnote.repository.PetNoteRepository;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.HomeErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeService {
+
+    private static final int NOTE_PAGE_SIZE = 20;
+
+    private final UserRepository userRepository;
+    private final PetRepository petRepository;
+    private final PetGuardianRepository petGuardianRepository;
+    private final PetNoteRepository petNoteRepository;
+    private final DailyChecklistRepository dailyChecklistRepository;
+
+    /**
+     * API 1: 반려동물 선택 저장.
+     * 해당 사용자가 petId 반려동물에 접근 권한이 있는지 검증 후 lastSelectedPetId 갱신.
+     */
+    @Transactional
+    public void selectPet(Long userId, Long petId) {
+        User user = getUserOrThrow(userId);
+        if (!petGuardianRepository.existsByPetIdAndUserId(petId, userId)) {
+            throw new BusinessException(HomeErrorCode.HOME_PET_ACCESS_DENIED);
+        }
+        user.updateLastSelectedPet(petId);
+        log.info("[HomeService] selectPet userId={}, petId={}", userId, petId);
+    }
+
+    /**
+     * API 2: 반려동물 목록 조회.
+     * 직접 등록(OWNER) + 공유받은(CAREGIVER) 반려동물을 합쳐 등록일 오름차순으로 반환.
+     * lastSelectedPetId를 함께 내려줌.
+     */
+    public HomePetListResponse getPetList(Long userId) {
+        User user = getUserOrThrow(userId);
+
+        List<PetGuardian> guardians = petGuardianRepository.findByUserId(userId);
+
+        List<HomePetSummaryResponse> pets = guardians.stream()
+                .sorted(Comparator.comparing(g -> g.getPet().getCreatedAt()))
+                .map(g -> {
+                    Pet pet = g.getPet();
+                    boolean isOwner = g.getRole() == PetGuardianRole.OWNER;
+                    return HomePetSummaryResponse.builder()
+                            .id(pet.getId())
+                            .name(pet.getName())
+                            .profileImageUrl(pet.getProfileImageUrl())
+                            .birthDate(pet.getBirthDate())
+                            .isBirthDateUnknown(pet.isBirthDateUnknown())
+                            .species(pet.getSpecies())
+                            .registrationType(isOwner ? "OWNER" : "SHARED")
+                            .role(g.getRole().name())
+                            .build();
+                })
+                .toList();
+
+        return HomePetListResponse.builder()
+                .lastSelectedPetId(user.getLastSelectedPetId())
+                .pets(pets)
+                .build();
+    }
+
+    /**
+     * API 3: 홈 화면 데이터 통합 조회.
+     * 반려동물 프로필, 케어 진행률, 메모 목록, 체크리스트 존재 여부를 한 번에 반환.
+     */
+    public HomeResponse getHomeData(Long userId, Long petId) {
+        User user = getUserOrThrow(userId);
+
+        List<PetGuardian> allGuardians = petGuardianRepository.findByUserId(userId);
+        boolean hasPets = !allGuardians.isEmpty();
+
+        if (!hasPets) {
+            return HomeResponse.builder()
+                    .hasPets(false)
+                    .build();
+        }
+
+        // petId가 없으면 lastSelectedPetId → 없으면 가장 최근 등록 반려동물
+        Long resolvedPetId = resolveSelectedPetId(user, petId, allGuardians);
+
+        PetGuardian myGuardian = petGuardianRepository.findByPetIdAndUserId(resolvedPetId, userId)
+                .orElseThrow(() -> new BusinessException(HomeErrorCode.HOME_PET_ACCESS_DENIED));
+        Pet pet = myGuardian.getPet();
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        HomePetProfileResponse petProfile = HomePetProfileResponse.builder()
+                .id(pet.getId())
+                .name(pet.getName())
+                .profileImageUrl(pet.getProfileImageUrl())
+                .role(myGuardian.getRole().name())
+                .build();
+
+        long totalCount = dailyChecklistRepository.countByPet_IdAndTargetDate(resolvedPetId, today);
+        long completedCount = dailyChecklistRepository.countByPet_IdAndTargetDateAndIsCompleted(resolvedPetId, today, true);
+
+        HomeCareProgressResponse careProgress = HomeCareProgressResponse.builder()
+                .totalCount(totalCount)
+                .completedCount(completedCount)
+                .build();
+
+        // 메모: 최신 20건, 마지막 로그인 이후 작성된 메모는 isNew=true
+        LocalDateTime lastLoginAt = user.getLastLoginAt();
+        List<PetNote> latestNotes = petNoteRepository.findLatestByPetIdWithWriter(
+                resolvedPetId, PageRequest.of(0, NOTE_PAGE_SIZE));
+
+        // 각 메모 작성자의 역할을 구하기 위해 guardianMap 준비
+        Map<Long, String> guardianRoleMap = buildGuardianRoleMap(resolvedPetId);
+
+        List<HomeNoteResponse> notes = latestNotes.stream().map(note -> {
+            Long writerId = note.getWrittenBy() != null ? note.getWrittenBy().getId() : null;
+            boolean isNew = lastLoginAt != null && note.getCreatedAt() != null
+                    && note.getCreatedAt().isAfter(lastLoginAt);
+            return HomeNoteResponse.builder()
+                    .id(note.getId())
+                    .content(note.getContent())
+                    .writtenByUserId(writerId)
+                    .writtenByNickname(note.getWrittenBy() != null ? note.getWrittenBy().getNickname() : null)
+                    .writtenByProfileImageUrl(note.getWrittenBy() != null ? note.getWrittenBy().getProfileImageUrl() : null)
+                    .writtenByRole(writerId != null ? guardianRoleMap.getOrDefault(writerId, null) : null)
+                    .sentAt(note.getCreatedAt())
+                    .isNew(isNew)
+                    .linkedChecklistId(note.getLinkedChecklistId())
+                    .build();
+        }).toList();
+
+        boolean hasChecklist = dailyChecklistRepository.existsByPet_IdAndTargetDate(resolvedPetId, today);
+
+        return HomeResponse.builder()
+                .hasPets(true)
+                .petProfile(petProfile)
+                .careProgress(careProgress)
+                .notes(notes)
+                .hasChecklist(hasChecklist)
+                .build();
+    }
+
+    /**
+     * API 4: 체크리스트 조회 (탭/카테고리 구분).
+     * DISEASE_CARE → 질병 케어 탭, 그 외 → 기본 케어 탭.
+     * 항목이 있는 카테고리만 반환.
+     */
+    public HomeChecklistResponse getChecklists(Long userId, Long petId, LocalDate date) {
+        if (!petGuardianRepository.existsByPetIdAndUserId(petId, userId)) {
+            throw new BusinessException(HomeErrorCode.HOME_PET_ACCESS_DENIED);
+        }
+
+        List<DailyChecklist> checklists = dailyChecklistRepository
+                .findAllByPetIdAndTargetDateWithUser(petId, date);
+
+        // careType 기준으로 그룹핑 (등장 순서 유지)
+        Map<CareType, List<HomeChecklistItemResponse>> groupMap = new LinkedHashMap<>();
+        for (DailyChecklist cl : checklists) {
+            groupMap.computeIfAbsent(cl.getCareType(), k -> new ArrayList<>())
+                    .add(toChecklistItemResponse(cl));
+        }
+
+        List<HomeChecklistCategoryResponse> basicCare = new ArrayList<>();
+        List<HomeChecklistCategoryResponse> diseaseCare = new ArrayList<>();
+
+        for (Map.Entry<CareType, List<HomeChecklistItemResponse>> entry : groupMap.entrySet()) {
+            HomeChecklistCategoryResponse category = HomeChecklistCategoryResponse.builder()
+                    .careType(entry.getKey().name())
+                    .careTypeDescription(entry.getKey().getDescription())
+                    .items(entry.getValue())
+                    .build();
+            if (entry.getKey() == CareType.DISEASE_CARE) {
+                diseaseCare.add(category);
+            } else {
+                basicCare.add(category);
+            }
+        }
+
+        return HomeChecklistResponse.builder()
+                .basicCare(basicCare)
+                .diseaseCare(diseaseCare)
+                .build();
+    }
+
+    // ─── helpers ──────────────────────────────────────────────────────────────
+
+    private HomeChecklistItemResponse toChecklistItemResponse(DailyChecklist cl) {
+        return HomeChecklistItemResponse.builder()
+                .id(cl.getId())
+                .title(cl.getTitle())
+                .content(cl.getContent())
+                .isCompleted(cl.isCompleted())
+                .isRequested(cl.getCareTemplate() != null)
+                .completedAt(cl.getCompletedAt())
+                .completedByProfileImageUrl(
+                        cl.getCompletedBy() != null ? cl.getCompletedBy().getProfileImageUrl() : null)
+                .completedByNickname(
+                        cl.getCompletedBy() != null ? cl.getCompletedBy().getNickname() : null)
+                .version(cl.getVersion())
+                .build();
+    }
+
+    /** 보호자 userId → role 문자열 맵 */
+    private Map<Long, String> buildGuardianRoleMap(Long petId) {
+        Map<Long, String> map = new HashMap<>();
+        petGuardianRepository.findByPetIdOrderByIdAsc(petId)
+                .forEach(g -> map.put(g.getUser().getId(), g.getRole().name()));
+        return map;
+    }
+
+    /**
+     * petId를 결정하는 우선순위:
+     * 1. 파라미터로 전달된 petId (접근 권한 검증 후)
+     * 2. lastSelectedPetId (보유 목록에 있는 경우)
+     * 3. 가장 최근에 등록된 반려동물
+     */
+    private Long resolveSelectedPetId(User user, Long petId, List<PetGuardian> guardians) {
+        if (petId != null) {
+            boolean hasAccess = guardians.stream().anyMatch(g -> g.getPet().getId().equals(petId));
+            if (hasAccess) return petId;
+        }
+        Long lastId = user.getLastSelectedPetId();
+        if (lastId != null) {
+            boolean stillValid = guardians.stream().anyMatch(g -> g.getPet().getId().equals(lastId));
+            if (stillValid) return lastId;
+        }
+        // 가장 최근 등록 반려동물(createdAt 최신)
+        return guardians.stream()
+                .max(Comparator.comparing(g -> g.getPet().getCreatedAt()))
+                .map(g -> g.getPet().getId())
+                .orElseThrow(() -> new BusinessException(HomeErrorCode.HOME_PET_NOT_FOUND));
+    }
+
+    private User getUserOrThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(HomeErrorCode.HOME_USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/mypage/controller/MypageController.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/mypage/controller/MypageController.java
@@ -4,12 +4,12 @@ import com.newleaseonlife.SafeDogBe.domain.mypage.dto.response.MypageResponse;
 import com.newleaseonlife.SafeDogBe.domain.mypage.dto.response.MypageMarketingConsentResponse;
 import com.newleaseonlife.SafeDogBe.domain.mypage.dto.request.MypageMarketingConsentRequest;
 import com.newleaseonlife.SafeDogBe.domain.notification.service.NotificationService;
-import com.newleaseonlife.SafeDogBe.domain.mypage.enums.MypagePetScope;
 import com.newleaseonlife.SafeDogBe.domain.term.service.TermService;
 import com.newleaseonlife.SafeDogBe.domain.mypage.service.MypageService;
 import com.newleaseonlife.SafeDogBe.global.security.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -40,9 +40,8 @@ public class MypageController {
       @RequestParam(defaultValue = "OWNER") String petScope,
       @AuthenticationPrincipal CustomPrincipal principal) {
     Long userId = principal.getUser().getId();
-    MypagePetScope scope = MypagePetScope.from(petScope);
     log.info("[MypageController] getMypage userId={}", userId);
-    return ResponseEntity.ok(mypageService.getMypage(userId, scope));
+    return ResponseEntity.ok(mypageService.getMypage(userId, petScope));
   }
 
   @Operation(summary = "마케팅 정보 수신 동의 조회", description = "마이페이지 마케팅 수신 ON/OFF 현재 상태를 반환합니다.")

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/mypage/service/MypageService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/mypage/service/MypageService.java
@@ -9,6 +9,8 @@ import com.newleaseonlife.SafeDogBe.domain.pet.dto.response.PetResponse;
 import com.newleaseonlife.SafeDogBe.domain.pet.service.PetService;
 import com.newleaseonlife.SafeDogBe.domain.user.dto.response.UserResponse;
 import com.newleaseonlife.SafeDogBe.domain.user.service.UserService;
+import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
+import com.newleaseonlife.SafeDogBe.global.error.domain.MypageErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -31,7 +33,11 @@ public class MypageService {
    * - 반려동물 scope(OWNER/SHARED)에 따른 목록(오래된 순)
    * - 각 반려동물의 보호자 목록
    */
-  public MypageResponse getMypage(Long userId, MypagePetScope petScope) {
+  /**
+   * @param petScopeQuery GET 파라미터 petScope 원문 (null/공백 → OWNER, 그 외 OWNER·SHARED만 허용)
+   */
+  public MypageResponse getMypage(Long userId, String petScopeQuery) {
+    MypagePetScope petScope = resolvePetScope(petScopeQuery);
     UserResponse user = userService.findById(userId);
 
     List<PetResponse> pets = (petScope == MypagePetScope.SHARED)
@@ -56,6 +62,17 @@ public class MypageService {
         .user(user)
         .pets(petSections)
         .build();
+  }
+
+  private MypagePetScope resolvePetScope(String value) {
+    if (value == null || value.isBlank()) {
+      return MypagePetScope.OWNER;
+    }
+    try {
+      return MypagePetScope.valueOf(value.trim().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new BusinessException(MypageErrorCode.MYPAGE_INVALID_PET_SCOPE);
+    }
   }
 
   private MypageGuardianPermissionResponse toPermissionResponse(PetGuardianResponse guardian) {

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/repository/PetGuardianRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/pet/repository/PetGuardianRepository.java
@@ -28,4 +28,7 @@ public interface PetGuardianRepository extends JpaRepository<PetGuardian, Long> 
 
     /** 특정 회원이 주어진 역할로 등록된 반려동물(보호자 연결) 목록 */
     List<PetGuardian> findByUser_IdAndRole(Long userId, PetGuardianRole role);
+
+    /** 특정 회원이 보호자로 등록된 모든 반려동물 목록 (OWNER + CAREGIVER) */
+    List<PetGuardian> findByUserId(Long userId);
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/converter/PetNoteConverter.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/converter/PetNoteConverter.java
@@ -20,6 +20,10 @@ public class PetNoteConverter {
                 .petId(entity.getPetId())
                 .noteDate(entity.getNoteDate())
                 .content(entity.getContent())
+                .writtenByUserId(entity.getWrittenBy() != null ? entity.getWrittenBy().getId() : null)
+                .writtenByNickname(entity.getWrittenBy() != null ? entity.getWrittenBy().getNickname() : null)
+                .writtenByProfileImageUrl(entity.getWrittenBy() != null ? entity.getWrittenBy().getProfileImageUrl() : null)
+                .linkedChecklistId(entity.getLinkedChecklistId())
                 .createdAt(entity.getCreatedAt())
                 .updatedAt(entity.getUpdatedAt())
                 .build();

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/request/PetNoteCreateRequest.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/dto/request/PetNoteCreateRequest.java
@@ -29,4 +29,7 @@ public class PetNoteCreateRequest {
 
     /** 메모 내용. 선택 */
     private String content;
+
+    /** 연결할 체크리스트 ID. 선택 */
+    private Long linkedChecklistId;
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/entity/PetNote.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/entity/PetNote.java
@@ -1,6 +1,7 @@
 package com.newleaseonlife.SafeDogBe.domain.petnote.entity;
 
 import com.newleaseonlife.SafeDogBe.domain.pet.entity.Pet;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
 import com.newleaseonlife.SafeDogBe.global.common.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -54,11 +55,22 @@ public class PetNote extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    /** 작성자. 탈퇴 시 SET NULL 처리 */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "written_by", foreignKey = @ForeignKey(name = "fk_pet_notes_writer"))
+    private User writtenBy;
+
+    /** 연결된 체크리스트 ID. 케어 완료와 연결된 메모에서 사용 (optional) */
+    @Column(name = "linked_checklist_id")
+    private Long linkedChecklistId;
+
     @Builder
-    public PetNote(Pet pet, LocalDate noteDate, String content) {
+    public PetNote(Pet pet, LocalDate noteDate, String content, User writtenBy, Long linkedChecklistId) {
         this.pet = pet;
         this.noteDate = noteDate;
         this.content = content;
+        this.writtenBy = writtenBy;
+        this.linkedChecklistId = linkedChecklistId;
     }
 
     /** 편의 메서드: petId가 필요한 경우를 위해 제공 */

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/repository/PetNoteRepository.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/repository/PetNoteRepository.java
@@ -2,7 +2,10 @@ package com.newleaseonlife.SafeDogBe.domain.petnote.repository;
 
 import com.newleaseonlife.SafeDogBe.domain.petnote.entity.PetNote;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -24,4 +27,8 @@ public interface PetNoteRepository extends JpaRepository<PetNote, Long> {
 
     /** 해당 반려동물에 노트 존재 여부 */
     boolean existsByPet_Id(Long petId);
+
+    /** 홈 화면: 반려동물의 최신 메모 목록 (작성자 패치조인, 최신순) */
+    @Query("SELECT n FROM PetNote n LEFT JOIN FETCH n.writtenBy WHERE n.pet.id = :petId ORDER BY n.createdAt DESC")
+    List<PetNote> findLatestByPetIdWithWriter(@Param("petId") Long petId, Pageable pageable);
 }

--- a/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/service/PetNoteService.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/domain/petnote/service/PetNoteService.java
@@ -8,10 +8,13 @@ import com.newleaseonlife.SafeDogBe.domain.petnote.dto.request.PetNoteUpdateRequ
 import com.newleaseonlife.SafeDogBe.domain.petnote.dto.response.PetNoteResponse;
 import com.newleaseonlife.SafeDogBe.domain.petnote.entity.PetNote;
 import com.newleaseonlife.SafeDogBe.domain.petnote.repository.PetNoteRepository;
+import com.newleaseonlife.SafeDogBe.domain.user.entity.User;
+import com.newleaseonlife.SafeDogBe.domain.user.repository.UserRepository;
 import com.newleaseonlife.SafeDogBe.global.error.BusinessException;
 import com.newleaseonlife.SafeDogBe.global.error.domain.CommonErrorCode;
 import com.newleaseonlife.SafeDogBe.global.error.domain.PetErrorCode;
 import com.newleaseonlife.SafeDogBe.global.error.domain.PetNoteErrorCode;
+import com.newleaseonlife.SafeDogBe.global.error.domain.UserErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +37,7 @@ public class PetNoteService {
 
     private final PetNoteRepository petNoteRepository;
     private final PetRepository petRepository;
+    private final UserRepository userRepository;
     private final PetNoteConverter petNoteConverter;
 
     /** 반려동물별 노트 목록(날짜 최신순). 소유자만 조회 가능 */
@@ -67,10 +71,14 @@ public class PetNoteService {
                 }
                 return new BusinessException(PetErrorCode.PET_ACCESS_DENIED);
             });
+        User writer = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
         PetNote note = PetNote.builder()
             .pet(pet)
             .noteDate(request.getNoteDate())
             .content(request.getContent())
+            .writtenBy(writer)
+            .linkedChecklistId(request.getLinkedChecklistId())
             .build();
         PetNote saved = petNoteRepository.save(note);
         return petNoteConverter.toResponse(saved);

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/HomeErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/HomeErrorCode.java
@@ -1,0 +1,32 @@
+package com.newleaseonlife.SafeDogBe.global.error.domain;
+
+import com.newleaseonlife.SafeDogBe.global.error.ApiCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import org.springframework.http.HttpStatus;
+
+/** 홈 화면 API 전용 비즈니스 오류 코드 */
+@AllArgsConstructor
+@Getter
+public enum HomeErrorCode implements ApiCode {
+
+    /** 선택/조회 대상 반려동물에 대한 보호자 권한 없음 */
+    HOME_PET_ACCESS_DENIED(HttpStatus.FORBIDDEN, 403, "홈에서 해당 반려동물에 접근할 권한이 없습니다."),
+
+    /** 기본 반려동물을 결정할 수 없음(데이터 불일치 등) */
+    HOME_PET_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "홈에서 조회할 반려동물을 찾을 수 없습니다."),
+
+    /** 홈 API 처리 중 회원 엔티티 미존재 */
+    HOME_USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "홈 화면 조회에 필요한 회원 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/MypageErrorCode.java
+++ b/src/main/java/com/newleaseonlife/SafeDogBe/global/error/domain/MypageErrorCode.java
@@ -1,0 +1,26 @@
+package com.newleaseonlife.SafeDogBe.global.error.domain;
+
+import com.newleaseonlife.SafeDogBe.global.error.ApiCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import org.springframework.http.HttpStatus;
+
+/** 마이페이지 API 전용 비즈니스 오류 코드 */
+@AllArgsConstructor
+@Getter
+public enum MypageErrorCode implements ApiCode {
+
+    /** GET /api/mypage 의 petScope 파라미터가 OWNER/SHARED 가 아님 */
+    MYPAGE_INVALID_PET_SCOPE(HttpStatus.BAD_REQUEST, 400, "petScope는 OWNER 또는 SHARED만 입력할 수 있습니다.");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> e.g. Close #이슈번호
#87

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) <br>
> e.g. Board 관련 DTO 구현 (생성/응답) <br>
> e.g. TodoList 관련 DTO 구현 (생성/수정/상태변경/응답)

- `HomeErrorCode` (`global/error/domain`): 홈 API 전용 비즈니스 오류 3종
- `MypageErrorCode` (`global/error/domain`): 마이페이지 `petScope` 검증 오류 1종
- `HomeService`: 홈 분기에서 `HomeErrorCode` 사용
- `MypageService` / `MypageController`: `petScope` 파싱 및 `MYPAGE_INVALID_PET_SCOPE` 처리

## 🛠️ 주요 변경 사항 및 리팩토링

> e.g. DTO 내부 `static class` 구조로 역할 분리 <br>
> e.g. `TodoStatus` enum 사용 (CHECKED / UNCHECKED)

📡 API 명세 (홈 · 마이페이지)

인증이 필요한 API는 `Authorization` 등 기존 정책과 동일합니다.

 홈 `/api/home`

| Method | Path | Query / Body | 성공 응답 | 비고 |
|--------|------|----------------|-----------|------|
| `PATCH` | `/api/home/selected-pet` | Body: `{ "petId": number }` (`SelectPetRequest`) | `204 No Content` | 보호자 아닌 반려동물이면 `HomeErrorCode.HOME_PET_ACCESS_DENIED` |
| `GET` | `/api/home/pets` | — | `HomePetListResponse` (`lastSelectedPetId`, `pets[]`) | 전용 홈 오류 없음(회원 없으면 상위 인증 계층에서 처리) |
| `GET` | `/api/home` | `petId` (optional) | `HomeResponse` | 반려동물 없으면 `hasPets: false` 등. 있을 때 권한/해석 실패 시 `HOME_PET_ACCESS_DENIED` / `HOME_PET_NOT_FOUND` / `HOME_USER_NOT_FOUND` |
| `GET` | `/api/home/checklists` | `petId` (required), `date` (optional, `yyyy-MM-dd`, 기본: 오늘 서울) | `HomeChecklistResponse` (`basicCare`, `diseaseCare`) | 권한 없으면 `HOME_PET_ACCESS_DENIED` |
| `POST` | `/api/home/checklists/{checklistId}/complete` | Path: `checklistId` | `DailyChecklistResponse` | 케어 도메인 오류 가능 (`CareErrorCode`: 미존재, 이미 완료, 당일 아님 등) |
| `POST` | `/api/home/checklists/{checklistId}/uncomplete` | Path: `checklistId` | `DailyChecklistResponse` | 위와 동일 (`CareErrorCode`) |

 마이페이지 `/api/mypage`

| Method | Path | Query / Body | 성공 응답 | 비고 |
|--------|------|----------------|-----------|------|
| `GET` | `/api/mypage` | `petScope` (optional, 기본 `OWNER`) — 허용: `OWNER`, `SHARED` | `MypageResponse` | 그 외 값 → `MypageErrorCode.MYPAGE_INVALID_PET_SCOPE` |
| `GET` | `/api/mypage/marketing` | — | `MypageMarketingConsentResponse` | 내부 `UserService`/`TermService` 등 기존 코드 |
| `PATCH` | `/api/mypage/marketing` | Body: `MypageMarketingConsentRequest` (`agreed`) | `MypageMarketingConsentResponse` | 위와 동일 |
| `GET` | `/api/mypage/app-version` | — | `String` (앱 버전 문자열) | 인증 없이도 가능 여부는 시큐리티 설정 따름 |

이번 PR에서 추가·적용한 오류 코드 (`BusinessException`)

| 구분 | 상수 | HTTP | code | 메시지 |
|------|------|------|------|--------|
| Home | `HOME_PET_ACCESS_DENIED` | 403 | 403 | 홈에서 해당 반려동물에 접근할 권한이 없습니다. |
| Home | `HOME_PET_NOT_FOUND` | 404 | 404 | 홈에서 조회할 반려동물을 찾을 수 없습니다. |
| Home | `HOME_USER_NOT_FOUND` | 404 | 404 | 홈 화면 조회에 필요한 회원 정보를 찾을 수 없습니다. |
| Mypage | `MYPAGE_INVALID_PET_SCOPE` | 400 | 400 | petScope는 OWNER 또는 SHARED만 입력할 수 있습니다. |

- 화면(기능 영역) 단위로 `ApiCode`를 분리해, 동일 HTTP 상태라도 메시지·코드로 홈 vs 기타 도메인 구분 가능
- `petScope` 검증을 `MypageService.resolvePetScope()`에 일원화 (`IllegalArgumentException`에 의존하지 않고 `BusinessException`으로 통일)

## ✅ 체크리스트

- [ ] 브랜치 전략(소문자)을 준수했나요?
- [ ] 커밋 메시지 규칙을 지켰나요?
- [ ] DTO에 필수 어노테이션(@Getter, @Builder 등)을 넣었나요?
- [ ] 최소 1명의 리뷰어 승인을 확인했나요?


## 💡 참고 사항

> e.g. 추후 Service / Controller 계층에서 해당 DTO를 사용할 예정입니다.

- `MypagePetScope` enum의 `from()`은 남아 있을 수 있으나, HTTP 진입은 `MypageService`의 `resolvePetScope` 기준으로 동작.